### PR TITLE
refactor: extract image compression helper

### DIFF
--- a/src/components/ai/ChatImageUpload.tsx
+++ b/src/components/ai/ChatImageUpload.tsx
@@ -6,6 +6,7 @@ import type { UploadedImage } from './ImageUpload';
 import { useAuth } from '@/context/AuthContext';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from '@/hooks/use-toast';
+import { compressImage } from '@/lib/image';
 interface ChatImageUploadProps {
   onImagesSelect: (images: UploadedImage[]) => void;
   maxImages?: number;
@@ -20,49 +21,6 @@ export function ChatImageUpload({
   className 
 }: ChatImageUploadProps) {
   const { user } = useAuth();
-
-  const compressImage = async (file: File): Promise<File> => {
-    return new Promise((resolve) => {
-      const canvas = document.createElement('canvas');
-      const ctx = canvas.getContext('2d')!;
-      const img = new Image();
-
-      img.onload = () => {
-        const maxWidth = 1024;
-        const maxHeight = 1024;
-        let { width, height } = img as HTMLImageElement;
-
-        if (width > height) {
-          if (width > maxWidth) {
-            height = (height * maxWidth) / width;
-            width = maxWidth;
-          }
-        } else {
-          if (height > maxHeight) {
-            width = (width * maxHeight) / height;
-            height = maxHeight;
-          }
-        }
-
-        canvas.width = width;
-        canvas.height = height;
-        ctx.drawImage(img, 0, 0, width, height);
-        canvas.toBlob(
-          (blob) => {
-            const compressedFile = new File([blob!], file.name, {
-              type: 'image/webp',
-              lastModified: Date.now(),
-            });
-            resolve(compressedFile);
-          },
-          'image/webp',
-          0.8
-        );
-      };
-
-      img.src = URL.createObjectURL(file);
-    });
-  };
 
   const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;

--- a/src/lib/image.ts
+++ b/src/lib/image.ts
@@ -1,0 +1,43 @@
+export async function compressImage(file: File): Promise<File> {
+  return new Promise((resolve) => {
+    const canvas = document.createElement('canvas');
+    const ctx = canvas.getContext('2d')!;
+    const img = new Image();
+
+    img.onload = () => {
+      const maxWidth = 1024;
+      const maxHeight = 1024;
+      let { width, height } = img as HTMLImageElement;
+
+      if (width > height) {
+        if (width > maxWidth) {
+          height = (height * maxWidth) / width;
+          width = maxWidth;
+        }
+      } else {
+        if (height > maxHeight) {
+          width = (width * maxHeight) / height;
+          height = maxHeight;
+        }
+      }
+
+      canvas.width = width;
+      canvas.height = height;
+      ctx.drawImage(img, 0, 0, width, height);
+      canvas.toBlob(
+        (blob) => {
+          const compressedFile = new File([blob!], file.name, {
+            type: 'image/webp',
+            lastModified: Date.now(),
+          });
+          resolve(compressedFile);
+        },
+        'image/webp',
+        0.8
+      );
+    };
+
+    img.src = URL.createObjectURL(file);
+  });
+}
+

--- a/src/pages/EnhancedTrainingCoachPage.tsx
+++ b/src/pages/EnhancedTrainingCoachPage.tsx
@@ -14,6 +14,7 @@ import { useThreadedConversation } from '@/hooks/useThreadedConversation';
 import { cn } from '@/lib/utils';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from '@/hooks/use-toast';
+import { compressImage } from '@/lib/image';
 export default function EnhancedTrainingCoachPage() {
   const { user } = useAuth();
   const [input, setInput] = useState('');
@@ -62,44 +63,6 @@ export default function EnhancedTrainingCoachPage() {
   };
 
   // Image helpers
-  const compressImage = async (file: File): Promise<File> => {
-    return new Promise((resolve) => {
-      const canvas = document.createElement('canvas');
-      const ctx = canvas.getContext('2d')!;
-      const img = new Image();
-      img.onload = () => {
-        const maxWidth = 1024;
-        const maxHeight = 1024;
-        let { width, height } = img as HTMLImageElement;
-        if (width > height) {
-          if (width > maxWidth) {
-            height = (height * maxWidth) / width;
-            width = maxWidth;
-          }
-        } else {
-          if (height > maxHeight) {
-            width = (width * maxHeight) / height;
-            height = maxHeight;
-          }
-        }
-        canvas.width = width;
-        canvas.height = height;
-        ctx.drawImage(img, 0, 0, width, height);
-        canvas.toBlob(
-          (blob) => {
-            const compressedFile = new File([blob!], file.name, {
-              type: 'image/webp',
-              lastModified: Date.now(),
-            });
-            resolve(compressedFile);
-          },
-          'image/webp',
-          0.8
-        );
-      };
-      img.src = URL.createObjectURL(file);
-    });
-  };
 
   const uploadFiles = async (files: File[]): Promise<UploadedImage[]> => {
     if (!user) return [];


### PR DESCRIPTION
## Summary
- create shared compressImage helper
- reuse shared helper in ChatImageUpload and EnhancedTrainingCoachPage

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 219 errors)

------
https://chatgpt.com/codex/tasks/task_e_68a1a7c44e7883268b047649c0f5ac99