### PR TITLE
refactor: reuse image compression util

### DIFF
--- a/src/components/ai/ImageUpload.tsx
+++ b/src/components/ai/ImageUpload.tsx
@@ -7,6 +7,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { useAuth } from '@/context/AuthContext';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from '@/hooks/use-toast';
+import { compressImage } from '@/lib/image';
 
 interface ImageUploadProps {
   onImagesChange: (images: UploadedImage[]) => void;
@@ -131,51 +132,6 @@ export function ImageUpload({ onImagesChange, maxImages = 4 }: ImageUploadProps)
       setUploading(false);
     }
   }, [user, images, maxImages, onImagesChange]);
-
-  const compressImage = async (file: File): Promise<File> => {
-    return new Promise((resolve) => {
-      const canvas = document.createElement('canvas');
-      const ctx = canvas.getContext('2d')!;
-      const img = new Image();
-
-      img.onload = () => {
-        const maxWidth = 1024;
-        const maxHeight = 1024;
-        let { width, height } = img;
-
-        if (width > height) {
-          if (width > maxWidth) {
-            height = (height * maxWidth) / width;
-            width = maxWidth;
-          }
-        } else {
-          if (height > maxHeight) {
-            width = (width * maxHeight) / height;
-            height = maxHeight;
-          }
-        }
-
-        canvas.width = width;
-        canvas.height = height;
-        
-        ctx.drawImage(img, 0, 0, width, height);
-        
-        canvas.toBlob(
-          (blob) => {
-            const compressedFile = new File([blob!], file.name, {
-              type: 'image/webp',
-              lastModified: Date.now(),
-            });
-            resolve(compressedFile);
-          },
-          'image/webp',
-          0.8
-        );
-      };
-
-      img.src = URL.createObjectURL(file);
-    });
-  };
 
   const removeImage = (id: string) => {
     const updatedImages = images.filter(img => img.id !== id);


### PR DESCRIPTION
## Summary
- remove local `compressImage` from `ImageUpload`
- reuse shared `compressImage` helper from `src/lib/image`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any and other issues in unrelated files)*
- `npx eslint src/components/ai/ImageUpload.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a1c6c4d6c88326a7bd029aa7599c9d