### PR TITLE
feat: add set duration tracking and preferences

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -508,6 +508,10 @@ export type Database = {
           set_number: number
           weight: number
           workout_id: string
+          estimated_set_duration: number | null
+          actual_start_time: string | null
+          actual_end_time: string | null
+          exercise_id: string | null
         }
         Insert: {
           completed?: boolean
@@ -519,6 +523,10 @@ export type Database = {
           set_number: number
           weight: number
           workout_id: string
+          estimated_set_duration?: number | null
+          actual_start_time?: string | null
+          actual_end_time?: string | null
+          exercise_id?: string | null
         }
         Update: {
           completed?: boolean
@@ -530,6 +538,10 @@ export type Database = {
           set_number?: number
           weight?: number
           workout_id?: string
+          estimated_set_duration?: number | null
+          actual_start_time?: string | null
+          actual_end_time?: string | null
+          exercise_id?: string | null
         }
         Relationships: [
           {
@@ -537,6 +549,47 @@ export type Database = {
             columns: ["workout_id"]
             isOneToOne: false
             referencedRelation: "workout_sessions"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      set_duration_patterns: {
+        Row: {
+          id: string
+          user_id: string
+          exercise_name: string
+          exercise_id: string | null
+          avg_duration_seconds: number
+          sample_count: number | null
+          last_updated: string | null
+          metadata: Json | null
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          exercise_name: string
+          exercise_id?: string | null
+          avg_duration_seconds?: number
+          sample_count?: number | null
+          last_updated?: string | null
+          metadata?: Json | null
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          exercise_name?: string
+          exercise_id?: string | null
+          avg_duration_seconds?: number
+          sample_count?: number | null
+          last_updated?: string | null
+          metadata?: Json | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "set_duration_patterns_exercise_id_fkey"
+            columns: ["exercise_id"]
+            isOneToOne: false
+            referencedRelation: "exercises"
             referencedColumns: ["id"]
           },
         ]
@@ -1377,6 +1430,7 @@ export type Database = {
           updated_at: string
           weight: number | null
           weight_unit: string | null
+          rest_timer_preferences: Json | null
         }
         Insert: {
           age?: number | null
@@ -1392,6 +1446,7 @@ export type Database = {
           updated_at?: string
           weight?: number | null
           weight_unit?: string | null
+          rest_timer_preferences?: Json | null
         }
         Update: {
           age?: number | null
@@ -1407,6 +1462,7 @@ export type Database = {
           updated_at?: string
           weight?: number | null
           weight_unit?: string | null
+          rest_timer_preferences?: Json | null
         }
         Relationships: []
       }

--- a/supabase/migrations/20250820160116-3529bc26-4090-4e4e-948b-930f0699627b.sql
+++ b/supabase/migrations/20250820160116-3529bc26-4090-4e4e-948b-930f0699627b.sql
@@ -1,0 +1,27 @@
+-- Add estimated set duration and actual timing fields to exercise_sets
+ALTER TABLE exercise_sets 
+ADD COLUMN estimated_set_duration INTEGER DEFAULT NULL,
+ADD COLUMN actual_start_time TIMESTAMP DEFAULT NULL,
+ADD COLUMN actual_end_time TIMESTAMP DEFAULT NULL;
+
+-- Create learning table for personalized estimates
+CREATE TABLE set_duration_patterns (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+  exercise_name TEXT NOT NULL,
+  exercise_id UUID REFERENCES exercises(id),
+  avg_duration_seconds INTEGER NOT NULL DEFAULT 30,
+  sample_count INTEGER DEFAULT 1,
+  last_updated TIMESTAMP DEFAULT NOW(),
+  metadata JSONB DEFAULT '{}',
+  UNIQUE(user_id, exercise_name)
+);
+
+-- Add RLS policies
+ALTER TABLE set_duration_patterns ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users can manage own duration patterns" ON set_duration_patterns
+  FOR ALL USING (auth.uid() = user_id);
+
+-- Update user preferences
+ALTER TABLE user_profiles 
+ADD COLUMN rest_timer_preferences JSONB DEFAULT '{"precisionMode": false, "showAdjustedRest": true}';


### PR DESCRIPTION
## Summary
- add migration for set duration tracking and rest timer preferences
- update save-complete-workout function to compute rest times and learn durations
- extend workout store with set timing map and rest timer preferences

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 264 problems (221 errors, 43 warnings))*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5eb8dd10c8326b7b9d7ec69881054