### PR TITLE
feat: track set duration and show adjusted rest timer

### DIFF
--- a/src/hooks/useAdjustedRestTime.ts
+++ b/src/hooks/useAdjustedRestTime.ts
@@ -1,0 +1,21 @@
+import { useMemo } from 'react';
+import { useWorkoutStore } from '@/store/workoutStore';
+
+// Hook to calculate adjusted rest time by subtracting estimated set duration
+export const useAdjustedRestTime = (timerId: string, totalInterval: number) => {
+  const setTimings = useWorkoutStore((state) => state.setTimings);
+
+  return useMemo(() => {
+    // Timer IDs are formatted as `${exercise}_set_${setNumber}`
+    const [exerciseId, setPart] = timerId.split('_set_');
+    const setKey = `${exerciseId}_${setPart || ''}`;
+    const timingData = setTimings.get(setKey);
+    const estimatedDuration = timingData?.estimatedDuration || 0; // in seconds
+    const adjustedRest = Math.max(totalInterval - estimatedDuration, 0);
+    return {
+      adjustedRest,
+      estimatedDuration,
+      hasEstimate: Boolean(estimatedDuration),
+    };
+  }, [timerId, totalInterval, setTimings]);
+};


### PR DESCRIPTION
## Summary
- track first interaction on sets and record end times to derive duration
- add hook and UI to display adjusted rest excluding set duration

## Testing
- `npm run lint` *(fails: Unexpected any)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5f59fb2b48326a307cab2643e281d