### PR TITLE
feat: add previous week stats and deltas

### DIFF
--- a/src/hooks/useBasicWorkoutStats.ts
+++ b/src/hooks/useBasicWorkoutStats.ts
@@ -2,10 +2,10 @@
 import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/context/AuthContext";
-import { 
-  startOfWeek, 
-  endOfWeek,
-  format 
+import {
+  startOfWeek,
+  format,
+  subDays
 } from "date-fns";
 import { DateRange } from 'react-day-picker';
 
@@ -20,6 +20,16 @@ export interface BasicWorkoutStats {
   weeklyReps: number;
   weeklySets: number;
   weeklyDuration: number;
+  lastWeekWorkouts: number;
+  lastWeekVolume: number;
+  lastWeekReps: number;
+  lastWeekSets: number;
+  lastWeekDuration: number;
+  workoutsDeltaPct: number;
+  volumeDeltaPct: number;
+  repsDeltaPct: number;
+  setsDeltaPct: number;
+  durationDeltaPct: number;
   dailyWorkouts: Record<string, number>;
 }
 
@@ -43,6 +53,9 @@ export const useBasicWorkoutStats = (dateRange?: DateRange) => {
         // Default to current week (Monday to Sunday)
         periodStart = startOfWeek(now, { weekStartsOn: 1 }); // Monday as start of week
       }
+
+      const lastWeekStart = subDays(periodStart, 7);
+      const lastWeekEnd = subDays(periodEnd, 7);
       
       console.log("Fetching workouts for period:", 
         format(periodStart, "yyyy-MM-dd"), "to", 
@@ -73,9 +86,19 @@ export const useBasicWorkoutStats = (dateRange?: DateRange) => {
         }
         
         const { data: periodWorkouts, error: periodError } = await query;
-          
+
         if (periodError) throw periodError;
-        
+
+        // Fetch workouts from previous week for comparison
+        const { data: lastWeekWorkoutsData, error: lastWeekError } = await supabase
+          .from('workout_sessions')
+          .select('*')
+          .eq('user_id', user.id)
+          .gte('start_time', lastWeekStart.toISOString())
+          .lte('start_time', lastWeekEnd.toISOString());
+
+        if (lastWeekError) throw lastWeekError;
+
         // Fetch workout sets for volume, reps, and sets calculation
         let setsQuery = supabase
           .from('exercise_sets')
@@ -90,19 +113,31 @@ export const useBasicWorkoutStats = (dateRange?: DateRange) => {
         }
         
         const { data: exerciseSets, error: setsError } = await setsQuery;
-          
+
         if (setsError) throw setsError;
-        
+
+        // Fetch sets from previous week for comparison
+        const { data: lastWeekSetsData, error: lastWeekSetsError } = await supabase
+          .from('exercise_sets')
+          .select('*, workout_sessions!inner(*)')
+          .eq('workout_sessions.user_id', user.id)
+          .gte('workout_sessions.start_time', lastWeekStart.toISOString())
+          .lte('workout_sessions.start_time', lastWeekEnd.toISOString());
+
+        if (lastWeekSetsError) throw lastWeekSetsError;
+
         // Calculate total and average duration
         const safeWorkouts = Array.isArray(allWorkouts) ? allWorkouts : [];
         const safePeriodWorkouts = Array.isArray(periodWorkouts) ? periodWorkouts : [];
         const safeSets = Array.isArray(exerciseSets) ? exerciseSets : [];
+        const safeLastWeekWorkouts = Array.isArray(lastWeekWorkoutsData) ? lastWeekWorkoutsData : [];
+        const safeLastWeekSets = Array.isArray(lastWeekSetsData) ? lastWeekSetsData : [];
         
         const totalWorkouts = safeWorkouts.length;
         const totalDuration = safeWorkouts.reduce((sum, w) => sum + (w.duration || 0), 0);
         const avgDuration = totalWorkouts > 0 ? Math.round(totalDuration / totalWorkouts) : 0;
         const lastWorkoutDate = safeWorkouts[0]?.start_time || null;
-        
+
         // Calculate weekly volume (weight * reps)
         const weeklyVolume = safeSets.reduce((sum, set) => {
           if (set.weight && set.reps && set.completed) {
@@ -110,7 +145,14 @@ export const useBasicWorkoutStats = (dateRange?: DateRange) => {
           }
           return sum;
         }, 0);
-        
+
+        const lastWeekVolume = safeLastWeekSets.reduce((sum, set) => {
+          if (set.weight && set.reps && set.completed) {
+            return sum + (set.weight * set.reps);
+          }
+          return sum;
+        }, 0);
+
         // Calculate weekly reps and sets
         const weeklyReps = safeSets.reduce((sum, set) => {
           if (set.reps && set.completed) {
@@ -118,11 +160,22 @@ export const useBasicWorkoutStats = (dateRange?: DateRange) => {
           }
           return sum;
         }, 0);
-        
+
         const weeklySets = safeSets.filter(set => set.completed).length;
-        
+
+        const lastWeekReps = safeLastWeekSets.reduce((sum, set) => {
+          if (set.reps && set.completed) {
+            return sum + set.reps;
+          }
+          return sum;
+        }, 0);
+
+        const lastWeekSets = safeLastWeekSets.filter(set => set.completed).length;
+
         // Calculate weekly duration
         const weeklyDuration = safePeriodWorkouts.reduce((sum, w) => sum + (w.duration || 0), 0);
+        const lastWeekDuration = safeLastWeekWorkouts.reduce((sum, w) => sum + (w.duration || 0), 0);
+        const lastWeekWorkouts = safeLastWeekWorkouts.length;
         
         // Calculate daily workout counts with a consistent day format
         const dailyWorkouts: Record<string, number> = {};
@@ -136,7 +189,7 @@ export const useBasicWorkoutStats = (dateRange?: DateRange) => {
         // Calculate streak
         let streakDays = 0;
         if (safeWorkouts.length > 0) {
-          const workoutDates = [...new Set(safeWorkouts.map(w => 
+          const workoutDates = [...new Set(safeWorkouts.map(w =>
             w.start_time ? new Date(w.start_time).toISOString().split('T')[0] : null
           ).filter(Boolean))].sort().reverse();
           
@@ -156,16 +209,32 @@ export const useBasicWorkoutStats = (dateRange?: DateRange) => {
             }
           }
         }
-        
+
+        const calcDeltaPct = (current: number, previous: number) => {
+          if (previous === 0) {
+            return current > 0 ? 100 : 0;
+          }
+          return Math.round(((current - previous) / previous) * 100);
+        };
+
+        const workoutsDeltaPct = calcDeltaPct(safePeriodWorkouts.length, lastWeekWorkouts);
+        const volumeDeltaPct = calcDeltaPct(weeklyVolume, lastWeekVolume);
+        const repsDeltaPct = calcDeltaPct(weeklyReps, lastWeekReps);
+        const setsDeltaPct = calcDeltaPct(weeklySets, lastWeekSets);
+        const durationDeltaPct = calcDeltaPct(weeklyDuration, lastWeekDuration);
+
         console.log("Workout stats calculated:", {
           totalWorkouts,
           periodWorkouts: safePeriodWorkouts.length,
           dailyWorkouts,
           weeklyVolume,
           weeklyReps,
-          weeklySets
+          weeklySets,
+          lastWeekVolume,
+          lastWeekReps,
+          lastWeekSets
         });
-        
+
         return {
           totalWorkouts,
           totalDuration,
@@ -177,6 +246,16 @@ export const useBasicWorkoutStats = (dateRange?: DateRange) => {
           weeklyReps,
           weeklySets,
           weeklyDuration,
+          lastWeekWorkouts,
+          lastWeekVolume,
+          lastWeekReps,
+          lastWeekSets,
+          lastWeekDuration,
+          workoutsDeltaPct,
+          volumeDeltaPct,
+          repsDeltaPct,
+          setsDeltaPct,
+          durationDeltaPct,
           dailyWorkouts
         };
       } catch (error) {


### PR DESCRIPTION
## Summary
- query previous week workouts and sets
- compute last-week metrics and percentage deltas vs current week

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any, @typescript-eslint/no-explicit-any and others)*

------
https://chatgpt.com/codex/tasks/task_e_68a5feb9837c8326bb3095ba92cc742c