### PR TITLE
feat: add AI motivation cache and weekly tonnage summary

### DIFF
--- a/src/services/openAIService.ts
+++ b/src/services/openAIService.ts
@@ -86,6 +86,33 @@ export class OpenAIService {
     }
   }
 
+  async generateMotivationForPeriod(params: {
+    tonnage: number;
+    sets: number;
+    reps: number;
+    deltaPct: number;
+    period: string;
+    periodType: 'week' | 'month';
+    locale: string;
+  }): Promise<string> {
+    try {
+      const { supabase } = await import('@/integrations/supabase/client');
+      const { data, error } = await supabase.functions.invoke('openai-motivation', {
+        body: params,
+      });
+
+      if (error) {
+        console.error('Edge function error:', error);
+        throw new Error(`Edge function error: ${error.message}`);
+      }
+
+      return data?.text || 'Keep pushing forward!';
+    } catch (err) {
+      console.error('generateMotivationForPeriod error:', err);
+      return 'Stay strong and keep moving!';
+    }
+  }
+
   private getFallbackResponse(workoutData: SafeWorkoutData): OpenAIResponse {
     return {
       suggestions: [

--- a/supabase/functions/openai-motivation/index.ts
+++ b/supabase/functions/openai-motivation/index.ts
@@ -1,0 +1,112 @@
+import "https://deno.land/x/xhr@0.1.0/mod.ts";
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+const openAiKey = Deno.env.get('OPENAI_API_KEY');
+const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    if (!openAiKey) {
+      throw new Error('OPENAI_API_KEY is not configured');
+    }
+
+    const supabase = createClient(supabaseUrl, serviceKey, {
+      global: { headers: { Authorization: req.headers.get('Authorization')! } },
+    });
+    const { data: { user }, error: userError } = await supabase.auth.getUser();
+    if (userError || !user) {
+      throw new Error('Unauthorized');
+    }
+
+    const { tonnage, sets, reps, deltaPct, period, periodType, locale } = await req.json();
+    if (typeof tonnage !== 'number' || typeof sets !== 'number' || typeof reps !== 'number' ||
+        typeof deltaPct !== 'number' || !period || !periodType || !locale) {
+      return new Response(JSON.stringify({ error: 'Invalid payload' }), { status: 400, headers: corsHeaders });
+    }
+
+    const cacheQuery = supabase
+      .from('ai_motivation_cache')
+      .select('text')
+      .eq('user_id', user.id)
+      .eq('period_type', periodType)
+      .eq('period_id', period)
+      .eq('locale', locale)
+      .maybeSingle();
+    const { data: cacheHit } = await cacheQuery;
+    if (cacheHit && cacheHit.text) {
+      return new Response(JSON.stringify({ text: cacheHit.text, cached: true }), {
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const systemPrompt = `You are a concise fitness coach. Generate a motivational, punchy message for the user’s Home screen. Max 2 lines, ≤ 140 characters total. Include the tonnage number and a relatable real‑world comparison. Use at most 2 emojis. Respond in ${locale}.`;
+    const userPrompt = `Period: ${periodType} ${period}\nTonnage: ${tonnage} kg (Δ ${deltaPct}% vs prior)\nSets: ${sets}, Reps: ${reps}\nOutput: 1 motivational message (no markdown).`;
+
+    let text = 'Great effort this week! Keep pushing forward 💪';
+    let fallback = false;
+    let success = false;
+
+    for (let attempt = 0; attempt < 2 && !success; attempt++) {
+      const response = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${openAiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: 'gpt-4.1-2025-04-14',
+          messages: [
+            { role: 'system', content: systemPrompt },
+            { role: 'user', content: userPrompt },
+          ],
+          max_tokens: 80,
+          temperature: 0.9,
+        }),
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+        text = data.choices?.[0]?.message?.content?.trim() || text;
+        success = true;
+      } else if (response.status === 429 || response.status >= 500) {
+        await new Promise(r => setTimeout(r, Math.random() * 400 + 300));
+      } else {
+        break;
+      }
+    }
+
+    if (!success) {
+      fallback = true;
+    }
+
+    await supabase.from('ai_motivation_cache').upsert({
+      user_id: user.id,
+      period_type: periodType,
+      period_id: period,
+      locale,
+      text,
+      updated_at: new Date().toISOString(),
+    });
+
+    return new Response(JSON.stringify({ text, cached: false, fallback }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    console.error('openai-motivation error:', error);
+    const fallbackText = 'Keep moving forward! Every rep counts 💪';
+    return new Response(JSON.stringify({ text: fallbackText, cached: false, fallback: true }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+});

--- a/supabase/migrations/20250824120000-a1b2c3d4-e5f6-7890-abcd-ef0123456789.sql
+++ b/supabase/migrations/20250824120000-a1b2c3d4-e5f6-7890-abcd-ef0123456789.sql
@@ -1,0 +1,31 @@
+-- Create cache table for AI-generated motivational text
+CREATE TABLE IF NOT EXISTS public.ai_motivation_cache (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  period_type TEXT CHECK (period_type IN ('week','month')),
+  period_id TEXT NOT NULL,
+  locale TEXT NOT NULL,
+  text TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now(),
+  UNIQUE (user_id, period_type, period_id, locale)
+);
+
+-- Enable row level security
+ALTER TABLE public.ai_motivation_cache ENABLE ROW LEVEL SECURITY;
+
+-- Allow users to view their own cached motivation
+CREATE POLICY "Users can view own motivation cache" ON public.ai_motivation_cache
+  FOR SELECT USING (auth.uid() = user_id);
+
+-- Allow users to insert their own cached motivation
+CREATE POLICY "Users can insert own motivation cache" ON public.ai_motivation_cache
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+-- Allow users to update their own cached motivation
+CREATE POLICY "Users can update own motivation cache" ON public.ai_motivation_cache
+  FOR UPDATE USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+-- Optional: service role can read all entries
+CREATE POLICY "Service role can read motivation cache" ON public.ai_motivation_cache
+  FOR SELECT USING (auth.role() = 'service_role');


### PR DESCRIPTION
## Summary
- cache weekly motivation lines via `ai_motivation_cache` table with strict RLS
- add `openai-motivation` edge function to fetch or store motivational text
- expose `generateMotivationForPeriod` in OpenAIService and show message on Weekly Summary

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any & require import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a6063fcee08326a83fead969233bfb