### PR TITLE
feat: epic motivation system for weekly stats

### DIFF
--- a/src/data/epic_equivalents.json
+++ b/src/data/epic_equivalents.json
@@ -1,0 +1,18 @@
+[
+  {"id":"pyramid_block","label":"pyramid stone block","baseKg":2500,"fact":"Great Pyramid used ~2.3M blocks, each ~2–3 tons.","emoji":"🏛️"},
+  {"id":"city_bus","label":"city bus","baseKg":12000,"fact":"Typical single bus curb weight ~12 metric tons.","emoji":"🚌"},
+  {"id":"shipping_container_20ft","label":"20ft shipping container (empty)","baseKg":2200,"fact":"Standard 20ft container tare mass ~2.2 t.","emoji":"📦"},
+  {"id":"granite_monolith_small","label":"granite monolith","baseKg":10000,"fact":"Small single-piece marker stones can weigh ~10 t.","emoji":"🗿"},
+  {"id":"temple_bell","label":"temple bronze bell","baseKg":5000,"fact":"Large bronze bells often weigh several tons.","emoji":"🔔"},
+  {"id":"roman_marble_slab","label":"Roman marble slab","baseKg":300,"fact":"Large dressed slabs used for floors/walls ~300 kg.","emoji":"🏛️"},
+  {"id":"steel_ibeam_6m","label":"steel I-beam (6 m)","baseKg":1100,"fact":"Example W12×40 over ~6 m ≈ 1.1 t.","emoji":"🏗️"},
+  {"id":"battering_ram_small","label":"medieval battering ram","baseKg":1000,"fact":"Smaller rams around a metric ton.","emoji":"🛡️"},
+  {"id":"grand_piano","label":"grand piano","baseKg":300,"fact":"Concert grands weigh ~300 kg.","emoji":"🎹"},
+  {"id":"barbell","label":"barbell","baseKg":20,"fact":"Standard Olympic barbell ~20 kg.","emoji":"🏋️"},
+  {"id":"african_lion","label":"African lion","baseKg":190,"fact":"Adult male averages ~190 kg.","emoji":"🦁"},
+  {"id":"siberian_tiger","label":"Siberian tiger","baseKg":220,"fact":"Adult male can reach ~220 kg.","emoji":"🐯"},
+  {"id":"polar_bear","label":"polar bear","baseKg":450,"fact":"Adult males often ~450 kg.","emoji":"🐻"},
+  {"id":"gorilla","label":"silverback gorilla","baseKg":160,"fact":"Adult silverbacks weigh ~160 kg.","emoji":"🦍"},
+  {"id":"great_white_shark","label":"great white shark","baseKg":1100,"fact":"Large adults exceed ~1,000 kg.","emoji":"🦈"},
+  {"id":"asian_elephant","label":"Asian elephant","baseKg":4000,"fact":"Adult Asian elephants ~4 t.","emoji":"🐘"}
+]

--- a/src/lib/equivalence.ts
+++ b/src/lib/equivalence.ts
@@ -1,0 +1,23 @@
+export type EpicItem = { id:string; label:string; baseKg:number; fact:string; emoji?:string };
+
+export function bestEpicMatch(tonnageKg: number, items: EpicItem[]) {
+  let best = { item: items[0], n: 1, approxKg: items[0].baseKg };
+  let bestDiff = Math.abs(tonnageKg - best.approxKg);
+  for (const item of items) {
+    const n = Math.min(60, Math.max(1, Math.round(tonnageKg / item.baseKg)) || 1);
+    const approxKg = n * item.baseKg;
+    const diff = Math.abs(tonnageKg - approxKg);
+    if (diff < bestDiff) {
+      best = { item, n, approxKg };
+      bestDiff = diff;
+    }
+  }
+  return best;
+}
+
+export function formatEquivalence({ item, n }: { item: EpicItem; n: number }) {
+  return {
+    text: `≈ ${n} ${item.label}${n > 1 ? 's' : ''}`,
+    emoji: item.emoji,
+  };
+}

--- a/supabase/functions/openai-motivation/index.ts
+++ b/supabase/functions/openai-motivation/index.ts
@@ -2,6 +2,28 @@ import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 
+import items from '../../../src/data/epic_equivalents.json' assert { type: 'json' };
+
+type EpicItem = { id: string; label: string; baseKg: number; fact: string; emoji?: string };
+
+function bestEpicMatch(tonnageKg: number, list: EpicItem[]) {
+  let best = { item: list[0], n: 1, approxKg: list[0].baseKg };
+  let bestDiff = Math.abs(tonnageKg - best.approxKg);
+  for (const item of list) {
+    const n = Math.min(60, Math.max(1, Math.round(tonnageKg / item.baseKg)) || 1);
+    const approxKg = n * item.baseKg;
+    const diff = Math.abs(tonnageKg - approxKg);
+    if (diff < bestDiff) {
+      best = { item, n, approxKg };
+      bestDiff = diff;
+    }
+  }
+  return best;
+}
+
+const allowedLabels = (items as EpicItem[]).map((i) => i.label);
+const allowedCsv = allowedLabels.join(', ');
+
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
@@ -29,9 +51,9 @@ serve(async (req) => {
       throw new Error('Unauthorized');
     }
 
-    const { tonnage, sets, reps, deltaPct, period, periodType, locale } = await req.json();
+    const { tonnage, sets, reps, deltaPct, period, periodType, locale, style } = await req.json();
     if (typeof tonnage !== 'number' || typeof sets !== 'number' || typeof reps !== 'number' ||
-        typeof deltaPct !== 'number' || !period || !periodType || !locale) {
+        typeof deltaPct !== 'number' || !period || !periodType || !locale || !style) {
       return new Response(JSON.stringify({ error: 'Invalid payload' }), { status: 400, headers: corsHeaders });
     }
 
@@ -42,22 +64,44 @@ serve(async (req) => {
       .eq('period_type', periodType)
       .eq('period_id', period)
       .eq('locale', locale)
+      .eq('style', style)
       .maybeSingle();
     const { data: cacheHit } = await cacheQuery;
     if (cacheHit && cacheHit.text) {
-      return new Response(JSON.stringify({ text: cacheHit.text, cached: true }), {
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      });
+      console.info('motivation cache hit');
+      let cachedItem: EpicItem | undefined;
+      let n: number | undefined;
+      for (const it of items as EpicItem[]) {
+        if (cacheHit.text.toLowerCase().includes(it.label.toLowerCase())) {
+          cachedItem = it;
+          n = Math.min(60, Math.max(1, Math.round(tonnage / it.baseKg)) || 1);
+          break;
+        }
+      }
+      return new Response(
+        JSON.stringify({
+          text: cacheHit.text,
+          variant: 'A',
+          item: cachedItem ? { ...cachedItem, n } : undefined,
+          cached: true,
+          fallback: false,
+        }),
+        { headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+      );
     }
+    console.info('motivation cache miss');
 
-    const systemPrompt = `You are a concise fitness coach. Generate a motivational, punchy message for the user’s Home screen. Max 2 lines, ≤ 140 characters total. Include the tonnage number and a relatable real‑world comparison. Use at most 2 emojis. Respond in ${locale}.`;
-    const userPrompt = `Period: ${periodType} ${period}\nTonnage: ${tonnage} kg (Δ ${deltaPct}% vs prior)\nSets: ${sets}, Reps: ${reps}\nOutput: 1 motivational message (no markdown).`;
+    const systemPrompt = `You are a concise, epic-tone strength coach. Output **max 2 lines**, **≤140 chars total**.\nLine 1: bold hook with the tonnage + one equivalence from the **allowed list** only (1–60 multiples).\nLine 2: a short educational nudge (no medical claims). Use at most **1 emoji**. Respond in ${locale}.\nAllowed items: ${allowedCsv}. Return **two variants** separated by |||. Plain text only.`;
+    const userPrompt = `Period: ${periodType} ${period}\nTonnage: ${tonnage} kg (Δ ${deltaPct}% vs prior)\nContext: sets ${sets}, reps ${reps}\nStyle: epic\nIf helpful, choose an item and integer multiple (1–60).`;
 
-    let text = 'Great effort this week! Keep pushing forward 💪';
+    let text = '';
+    let chosenItem: EpicItem | undefined;
+    let variant: 'A' | 'B' = 'A';
     let fallback = false;
     let success = false;
 
     for (let attempt = 0; attempt < 2 && !success; attempt++) {
+      const start = Date.now();
       const response = await fetch('https://api.openai.com/v1/chat/completions', {
         method: 'POST',
         headers: {
@@ -74,10 +118,29 @@ serve(async (req) => {
           temperature: 0.9,
         }),
       });
+      console.info('openai response', response.status, 'latency', Date.now() - start);
 
       if (response.ok) {
         const data = await response.json();
-        text = data.choices?.[0]?.message?.content?.trim() || text;
+        const raw = data.choices?.[0]?.message?.content?.trim() || '';
+        const variants = raw.split('|||').map((v: string) => v.trim());
+        for (let i = 0; i < variants.length; i++) {
+          const v = variants[i];
+          const found = (items as EpicItem[]).find(it => v.toLowerCase().includes(it.label.toLowerCase()));
+          if (found) {
+            text = v;
+            chosenItem = found;
+            variant = i === 0 ? 'A' : 'B';
+            break;
+          }
+        }
+        if (!text) {
+          const match = bestEpicMatch(tonnage, items as EpicItem[]);
+          chosenItem = match.item;
+          const equiv = `≈ ${match.n} ${match.item.label}${match.n > 1 ? 's' : ''}`;
+          text = `${tonnage} kg — ${equiv}\n${match.item.fact}`;
+          fallback = true;
+        }
         success = true;
       } else if (response.status === 429 || response.status >= 500) {
         await new Promise(r => setTimeout(r, Math.random() * 400 + 300));
@@ -87,6 +150,10 @@ serve(async (req) => {
     }
 
     if (!success) {
+      const match = bestEpicMatch(tonnage, items as EpicItem[]);
+      chosenItem = match.item;
+      const equiv = `≈ ${match.n} ${match.item.label}${match.n > 1 ? 's' : ''}`;
+      text = `${tonnage} kg — ${equiv}\n${match.item.fact}`;
       fallback = true;
     }
 
@@ -95,18 +162,22 @@ serve(async (req) => {
       period_type: periodType,
       period_id: period,
       locale,
+      style,
       text,
       updated_at: new Date().toISOString(),
     });
 
-    return new Response(JSON.stringify({ text, cached: false, fallback }), {
+    const n = chosenItem ? Math.min(60, Math.max(1, Math.round(tonnage / chosenItem.baseKg)) || 1) : undefined;
+
+    return new Response(JSON.stringify({ text, variant, item: chosenItem ? { ...chosenItem, n } : undefined, cached: false, fallback }), {
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });
   } catch (error) {
     console.error('openai-motivation error:', error);
-    const fallbackText = 'Keep moving forward! Every rep counts 💪';
+    const fallbackText = 'Keep moving forward! Every rep counts.';
     return new Response(JSON.stringify({ text: fallbackText, cached: false, fallback: true }), {
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });
   }
 });
+


### PR DESCRIPTION
## Summary
- add curated epic equivalence catalog and helper utilities
- enhance openai-motivation edge function with whitelist validation and caching
- show epic motivation card under weekly stats with trend and refresh

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any / require import)*

------
https://chatgpt.com/codex/tasks/task_e_68a61591a4bc8326983b0ea5a8fa2bac