### PR TITLE
feat: apply glass styling to weekly tonnage card

### DIFF
--- a/src/components/MotivationCard.tsx
+++ b/src/components/MotivationCard.tsx
@@ -1,0 +1,136 @@
+import React, { useState } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "@/components/ui/tooltip";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+import { Info, RefreshCw } from "lucide-react";
+
+interface MotivationCardProps {
+  tonnage: number;
+  deltaPct?: number;
+  coachCopy?: string;
+  loading?: boolean;
+  loadingCoach?: boolean;
+  onRefresh: () => void;
+  locale: string;
+}
+
+interface Equivalence {
+  weight: number;
+  label: string;
+  emoji: string;
+  fact: string;
+}
+
+const EQUIVALENTS: Equivalence[] = [
+  { weight: 70, label: "person", emoji: "🧍", fact: "An average person weighs about 70 kg." },
+  { weight: 400, label: "grand piano", emoji: "🎹", fact: "A grand piano weighs roughly 400 kg." },
+  { weight: 1000, label: "small car", emoji: "🚗", fact: "A small car weighs around 1,000 kg." },
+  { weight: 3000, label: "hippopotamus", emoji: "🦛", fact: "A hippo can weigh about 3,000 kg." },
+  { weight: 6000, label: "elephant", emoji: "🐘", fact: "An African elephant weighs around 6,000 kg." },
+];
+
+function getEquivalence(tonnage: number) {
+  if (tonnage <= 0) return null;
+  const eq = [...EQUIVALENTS].reverse().find(item => tonnage / item.weight >= 1) || EQUIVALENTS[0];
+  const n = Math.round(tonnage / eq.weight);
+  return { ...eq, n };
+}
+
+export const MotivationCard: React.FC<MotivationCardProps> = ({
+  tonnage,
+  deltaPct = 0,
+  coachCopy,
+  loading,
+  loadingCoach,
+  onRefresh,
+  locale,
+}) => {
+  const equivalence = getEquivalence(tonnage);
+  const trend = Math.round(deltaPct);
+  let trendSymbol = "—";
+  let trendClasses = "text-[#A3AED0] border-white/10";
+  if (tonnage > 0) {
+    if (trend > 0) {
+      trendSymbol = "▲";
+      trendClasses = "text-emerald-400 border-emerald-400/30";
+    } else if (trend < 0) {
+      trendSymbol = "▼";
+      trendClasses = "text-rose-400 border-rose-400/30";
+    }
+  }
+
+  const [rotated, setRotated] = useState(false);
+  const handleRefresh = () => {
+    setRotated(r => !r);
+    onRefresh();
+  };
+
+  return (
+    <Card className="relative rounded-2xl border border-white/10 bg-white/5 backdrop-blur shadow-[0_1px_0_0_rgba(255,255,255,0.04),0_16px_40px_-20px_rgba(0,0,0,0.6)]">
+      <div className="absolute top-0 left-0 right-0 h-0.5 rounded-t-2xl bg-gradient-to-r from-fuchsia-500 via-violet-500 to-cyan-400" />
+      <CardContent className="flex items-start justify-between gap-3 p-3">
+        <div className="flex-1">
+          <div className="text-xs text-[#9AA3B2] mb-1">Weekly Tonnage</div>
+          {loading ? (
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-7 w-24" />
+              <Skeleton className="h-5 w-16 rounded-full" />
+            </div>
+          ) : (
+            <div className="flex items-center gap-2" aria-live="polite">
+              <span className="text-2xl font-semibold tabular-nums text-white">
+                {tonnage.toLocaleString(locale)}
+              </span>
+              <span className="text-sm font-normal text-white/80 ml-1">kg</span>
+              {tonnage > 0 && equivalence && (
+                <span className="text-xs px-2 py-0.5 rounded-full bg-white/10 text-white/90">
+                  ≈ {equivalence.n.toLocaleString(locale)} {equivalence.label}
+                  {equivalence.n > 1 ? 's' : ''} {equivalence.emoji}
+                </span>
+              )}
+              {tonnage > 0 && (
+                <span className={cn("text-[10px] px-1.5 py-0.5 rounded-full border", trendClasses)}>
+                  {trendSymbol === '—' ? '—' : `${trendSymbol} ${Math.abs(trend)}%`}
+                </span>
+              )}
+            </div>
+          )}
+          {loadingCoach ? (
+            <Skeleton className="h-4 w-3/5 mt-1" />
+          ) : (
+            <p className="text-sm text-[#9AA3B2] mt-1 line-clamp-2">
+              {tonnage === 0 ? 'Keep lifting—every rep counts.' : coachCopy}
+            </p>
+          )}
+        </div>
+        <div className="flex items-center gap-2 self-center">
+          {tonnage > 0 && equivalence && (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button className="opacity-70 hover:opacity-100">
+                    <Info className="h-4 w-4 text-white" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>{equivalence.fact}</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={handleRefresh}
+            className={cn("h-8 w-8 transition-transform", rotated && "motion-safe:rotate-180")}
+            iconOnly
+          >
+            <RefreshCw className="h-4 w-4" />
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default MotivationCard;

--- a/src/components/WeeklySummaryStats.tsx
+++ b/src/components/WeeklySummaryStats.tsx
@@ -4,6 +4,7 @@ import { useBasicWorkoutStats } from "@/hooks/useBasicWorkoutStats";
 import { useDateRange } from '@/context/DateRangeContext';
 import { format, differenceInCalendarDays, subDays, getDay, startOfWeek } from "date-fns";
 import { Calendar, Dumbbell, Repeat, Layers, Clock } from "lucide-react";
+import MotivationCard from "./MotivationCard";
 import { useAuth } from '@/context/AuthContext';
 import { useQuery } from '@tanstack/react-query';
 import { OpenAIService } from '@/services/openAIService';
@@ -371,23 +372,16 @@ export const WeeklySummaryStats = React.memo(() => {
   {/* Week Progress Bar */}
   <WeekProgressBar currentDay={currentDayOfWeek} />
 
-  <div ref={motivationRef} className="bg-zinc-900/50 rounded-xl p-4 border border-zinc-800">
-    <div className="flex items-center justify-between mb-1">
-      <span className="text-sm text-muted-foreground">Weekly Tonnage</span>
-      <button
-        onClick={() => refetchMotivation()}
-        disabled={loadingMotivation}
-        className="text-xs text-zinc-400 hover:text-white"
-      >
-        ↻
-      </button>
-    </div>
-    <div className="text-xl font-semibold">
-      {(weekStats.volume.current || 0).toLocaleString()} kg lifted
-    </div>
-    <div className="text-xs text-muted-foreground mt-1">
-      {loadingMotivation ? 'Loading...' : motivationText || 'Keep it up!'}
-    </div>
+  <div ref={motivationRef}>
+    <MotivationCard
+      tonnage={weekStats.volume.current || 0}
+      deltaPct={stats?.volumeDeltaPct || 0}
+      coachCopy={motivationText || 'Keep it up!'}
+      loading={isLoading}
+      loadingCoach={loadingMotivation}
+      onRefresh={refetchMotivation}
+      locale={locale}
+    />
   </div>
 
   {/* Stats Grid */}


### PR DESCRIPTION
## Summary
- add Option A glass motivation card with accent bar, equivalence, trend pill, coach copy, and icon actions
- integrate motivation card into weekly summary under Start CTA

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: no-explicit-any errors and other lint issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a61c4ac86c8326ba5cc09ae2c6e77d