### PR TITLE
Refactor AI coach training-history retrieval

### DIFF
--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,8 @@
+export function formatLocalDate(utcISOString: string, timeZone: string = 'Europe/Warsaw') {
+  if (!utcISOString) return '';
+  try {
+    return new Intl.DateTimeFormat('pl-PL', { timeZone }).format(new Date(utcISOString));
+  } catch {
+    return utcISOString;
+  }
+}

--- a/supabase/functions/_shared/pagination.ts
+++ b/supabase/functions/_shared/pagination.ts
@@ -1,0 +1,15 @@
+export interface Cursor {
+  ts: string;
+  id: string | number;
+}
+
+export function buildCursorFilter(cursor: Cursor | null) {
+  if (!cursor) return undefined;
+  const { ts, id } = cursor;
+  return [
+    `start_time.gt.${ts}`,
+    `and(start_time.eq.${ts},id.gt.${id})`,
+    `and(start_time.is.null,created_at.gt.${ts})`,
+    `and(start_time.is.null,created_at.eq.${ts},id.gt.${id})`
+  ].join(',');
+}

--- a/supabase/functions/_shared/time.ts
+++ b/supabase/functions/_shared/time.ts
@@ -1,0 +1,8 @@
+export function formatLocalDate(utcISOString: string, timeZone: string = 'Europe/Warsaw') {
+  if (!utcISOString) return '';
+  try {
+    return new Intl.DateTimeFormat('pl-PL', { timeZone }).format(new Date(utcISOString));
+  } catch {
+    return utcISOString;
+  }
+}

--- a/supabase/functions/_shared/training-data.ts
+++ b/supabase/functions/_shared/training-data.ts
@@ -1,0 +1,224 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { buildCursorFilter, Cursor } from './pagination.ts';
+
+const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+export const supabaseAdmin = createClient(supabaseUrl, supabaseKey);
+
+export async function fetchTrainingData(userId: string) {
+  const pageSize = parseInt(Deno.env.get('AI_PAGE_SIZE') ?? '500', 10);
+  const nMax = parseInt(Deno.env.get('AI_N_MAX') ?? '50000', 10);
+  let cursor: Cursor | null = null;
+  const sessions: any[] = [];
+  let pages = 0;
+  let totalFetched = 0;
+  let minUTC: string | null = null;
+  let maxUTC: string | null = null;
+
+  while (true) {
+    let q = supabaseAdmin
+      .from('workout_sessions')
+      .select('*')
+      .eq('user_id', userId)
+      .order('start_time', { ascending: true, nullsFirst: true })
+      .order('created_at', { ascending: true })
+      .order('id', { ascending: true })
+      .limit(pageSize);
+
+    const filter = buildCursorFilter(cursor);
+    if (filter) q = q.or(filter);
+
+    const { data, error } = await q;
+    if (error) throw error;
+    if (!data || data.length === 0) break;
+
+    sessions.push(...data);
+    pages++;
+    totalFetched += data.length;
+
+    const firstTs = data[0].start_time ?? data[0].created_at;
+    const last = data[data.length - 1];
+    const lastTs = last.start_time ?? last.created_at;
+    if (!minUTC || firstTs < minUTC) minUTC = firstTs;
+    if (!maxUTC || lastTs > maxUTC) maxUTC = lastTs;
+
+    if (Deno.env.get('AI_AUDIT') === '1') {
+      console.info({
+        tag: 'AI_COACH_FETCH',
+        userId,
+        role: 'service',
+        page: pages,
+        pageSize,
+        got: data.length,
+        minUTC: firstTs,
+        maxUTC: lastTs,
+        totalFetched,
+      });
+    }
+
+    if (data.length < pageSize || totalFetched >= nMax) break;
+    cursor = { ts: lastTs, id: last.id };
+  }
+
+  const earliestSessionUTC = sessions[0]?.start_time ?? sessions[0]?.created_at ?? null;
+
+  if (Deno.env.get('AI_AUDIT') === '1') {
+    console.info({
+      tag: 'AI_COACH_FETCH_SUMMARY',
+      userId,
+      totalFetched,
+      pages,
+      minUTC,
+      maxUTC,
+      earliestSessionUTC,
+    });
+  }
+
+  const workoutIds = sessions.map((w) => w.id);
+
+  const { data: exerciseSets } = await supabaseAdmin
+    .from('exercise_sets')
+    .select('*')
+    .in('workout_id', workoutIds)
+    .order('workout_id', { ascending: true });
+
+  const { data: personalRecords } = await supabaseAdmin
+    .from('personal_records')
+    .select('*')
+    .eq('user_id', userId)
+    .order('date', { ascending: false })
+    .limit(10);
+
+  const totalWorkouts = sessions.length;
+  const totalSets = exerciseSets?.filter((set: any) => set.completed).length || 0;
+  const totalVolume =
+    exerciseSets?.reduce(
+      (sum: number, set: any) => (set.completed ? sum + set.weight * set.reps : sum),
+      0,
+    ) || 0;
+
+  const detailedWorkouts = sessions.map((workout) => {
+    const workoutSets = exerciseSets?.filter((set: any) => set.workout_id === workout.id) || [];
+
+    const exerciseGroups = workoutSets.reduce((acc: any, set: any) => {
+      if (!acc[set.exercise_name]) {
+        acc[set.exercise_name] = {
+          exercise_name: set.exercise_name,
+          sets: [],
+        };
+      }
+      acc[set.exercise_name].sets.push({
+        set_number: set.set_number,
+        weight: set.weight,
+        reps: set.reps,
+        completed: set.completed,
+        rest_time: set.rest_time,
+      });
+      return acc;
+    }, {} as Record<string, { exercise_name: string; sets: any[] }>);
+
+    return {
+      ...workout,
+      exercises: Object.values(exerciseGroups),
+      total_sets: workoutSets.length,
+      total_volume: workoutSets.reduce(
+        (sum: number, set: any) => (set.completed ? sum + set.weight * set.reps : sum),
+        0,
+      ),
+      exercises_performed: Object.keys(exerciseGroups).length,
+    };
+  });
+
+  const exerciseStats = exerciseSets?.reduce((acc: any, set: any) => {
+    if (!set.completed) return acc;
+    if (!acc[set.exercise_name]) {
+      acc[set.exercise_name] = {
+        volume: 0,
+        frequency: 0,
+        total_sets: 0,
+        max_weight: 0,
+        total_reps: 0,
+        workouts_performed: new Set(),
+        rest_times: [],
+      };
+    }
+    const stats = acc[set.exercise_name];
+    stats.volume += set.weight * set.reps;
+    stats.frequency += 1;
+    stats.total_sets += 1;
+    stats.total_reps += set.reps;
+    stats.max_weight = Math.max(stats.max_weight, set.weight);
+    stats.workouts_performed.add(set.workout_id);
+    if (set.rest_time && set.rest_time > 0) {
+      stats.rest_times.push(set.rest_time);
+    }
+    return acc;
+  }, {} as Record<string, {
+    volume: number;
+    frequency: number;
+    total_sets: number;
+    max_weight: number;
+    total_reps: number;
+    workouts_performed: Set<string>;
+    rest_times: number[];
+  }>);
+
+  const exerciseRestAnalytics = Object.entries(exerciseStats || {}).reduce(
+    (acc: any, [name, stats]: any) => {
+      if (stats.rest_times.length > 0) {
+        const avgRestTime =
+          stats.rest_times.reduce((sum: number, time: number) => sum + time, 0) /
+          stats.rest_times.length;
+        const minRestTime = Math.min(...stats.rest_times);
+        const maxRestTime = Math.max(...stats.rest_times);
+        acc[name] = {
+          average_rest: Math.round(avgRestTime),
+          min_rest: minRestTime,
+          max_rest: maxRestTime,
+          rest_consistency:
+            stats.rest_times.length > 1
+              ? Math.round(
+                  stats.rest_times.reduce((variance: number, time: number) => {
+                    const diff = time - avgRestTime;
+                    return variance + diff * diff;
+                  }, 0) / stats.rest_times.length,
+                )
+              : 0,
+        };
+      }
+      return acc;
+    },
+    {} as Record<string, { average_rest: number; min_rest: number; max_rest: number; rest_consistency: number }>,
+  );
+
+  const topExercises = Object.entries(exerciseStats || {})
+    .map(([name, stats]: [string, any]) => ({
+      name,
+      volume: stats.volume,
+      frequency: stats.frequency,
+      total_sets: stats.total_sets,
+      max_weight: stats.max_weight,
+      total_reps: stats.total_reps,
+      workouts_performed: stats.workouts_performed.size,
+      average_rest_time: exerciseRestAnalytics[name]?.average_rest || null,
+    }))
+    .sort((a: any, b: any) => b.volume - a.volume)
+    .slice(0, 10);
+
+  return {
+    totalWorkouts,
+    totalVolume,
+    totalSets,
+    recentWorkouts: detailedWorkouts.slice(0, 10),
+    allWorkouts: detailedWorkouts,
+    topExercises,
+    personalRecords: personalRecords || [],
+    exerciseBreakdown: exerciseStats,
+    restAnalytics: exerciseRestAnalytics,
+    earliestSessionUTC,
+    totalFetched,
+    pages,
+    minUTC,
+    maxUTC,
+  };
+}

--- a/supabase/functions/ai-training-data/index.ts
+++ b/supabase/functions/ai-training-data/index.ts
@@ -1,0 +1,27 @@
+import "https://deno.land/x/xhr@0.1.0/mod.ts";
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { fetchTrainingData } from "../_shared/training-data.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+  try {
+    const { userId } = await req.json();
+    const data = await fetchTrainingData(userId);
+    return new Response(JSON.stringify(data), {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  } catch (err) {
+    console.error("ai-training-data error", err);
+    return new Response(JSON.stringify({ error: err.message }), {
+      status: 500,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+});

--- a/supabase/functions/openai-training-coach/index.ts
+++ b/supabase/functions/openai-training-coach/index.ts
@@ -1,6 +1,8 @@
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { fetchTrainingData } from "../_shared/training-data.ts";
+import { formatLocalDate } from "../_shared/time.ts";
 
 const openAIApiKey = Deno.env.get('OPENAI_API_KEY');
 const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
@@ -44,7 +46,7 @@ serve(async (req) => {
     }
 
     // Get user's training data
-    const trainingData = await getUserTrainingData(userId);
+    const trainingData = await fetchTrainingData(userId);
     console.log('Training data fetched:', { 
       totalWorkouts: trainingData.totalWorkouts,
       totalVolume: trainingData.totalVolume 
@@ -185,172 +187,14 @@ Keep responses conversational but data-driven. Always reference their actual tra
   }
 });
 
-async function getUserTrainingData(userId: string) {
-  const threeMonthsAgo = new Date();
-  threeMonthsAgo.setMonth(threeMonthsAgo.getMonth() - 3);
-  
-  // Fetch workouts with detailed exercise data
-  const { data: workouts } = await supabase
-    .from('workout_sessions')
-    .select('*')
-    .eq('user_id', userId)
-    .gte('start_time', threeMonthsAgo.toISOString())
-    .order('start_time', { ascending: false });
-
-  // Fetch exercise sets with workout details
-  const workoutIds = workouts?.map(w => w.id) || [];
-  const { data: exerciseSets } = await supabase
-    .from('exercise_sets')
-    .select(`
-      *,
-      workout_sessions!inner(
-        id,
-        name,
-        training_type,
-        start_time,
-        end_time,
-        duration,
-        notes
-      )
-    `)
-    .in('workout_id', workoutIds)
-    .order('workout_id', { ascending: false });
-
-  // Fetch personal records
-  const { data: personalRecords } = await supabase
-    .from('personal_records')
-    .select('*')
-    .eq('user_id', userId)
-    .order('date', { ascending: false })
-    .limit(10);
-
-  const totalWorkouts = workouts?.length || 0;
-  const totalSets = exerciseSets?.filter(set => set.completed).length || 0;
-  const totalVolume = exerciseSets?.reduce((sum, set) => 
-    set.completed ? sum + (set.weight * set.reps) : sum, 0) || 0;
-
-  // Create detailed workout sessions with exercises
-  const detailedWorkouts = workouts?.map(workout => {
-    const workoutSets = exerciseSets?.filter(set => set.workout_id === workout.id) || [];
-    
-    // Group sets by exercise
-    const exerciseGroups = workoutSets.reduce((acc, set) => {
-      if (!acc[set.exercise_name]) {
-        acc[set.exercise_name] = {
-          exercise_name: set.exercise_name,
-          sets: []
-        };
-      }
-      acc[set.exercise_name].sets.push({
-        set_number: set.set_number,
-        weight: set.weight,
-        reps: set.reps,
-        completed: set.completed,
-        rest_time: set.rest_time
-      });
-      return acc;
-    }, {} as Record<string, { exercise_name: string; sets: any[] }>);
-
-    return {
-      ...workout,
-      exercises: Object.values(exerciseGroups),
-      total_sets: workoutSets.length,
-      total_volume: workoutSets.reduce((sum, set) => 
-        set.completed ? sum + (set.weight * set.reps) : sum, 0),
-      exercises_performed: Object.keys(exerciseGroups).length
-    };
-  }) || [];
-
-  // Calculate exercise stats with rest time analytics
-  const exerciseStats = exerciseSets?.reduce((acc, set) => {
-    if (!set.completed) return acc;
-    
-    if (!acc[set.exercise_name]) {
-      acc[set.exercise_name] = { 
-        volume: 0, 
-        frequency: 0, 
-        total_sets: 0,
-        max_weight: 0,
-        total_reps: 0,
-        workouts_performed: new Set(),
-        rest_times: []
-      };
-    }
-    acc[set.exercise_name].volume += set.weight * set.reps;
-    acc[set.exercise_name].frequency += 1;
-    acc[set.exercise_name].total_sets += 1;
-    acc[set.exercise_name].total_reps += set.reps;
-    acc[set.exercise_name].max_weight = Math.max(acc[set.exercise_name].max_weight, set.weight);
-    acc[set.exercise_name].workouts_performed.add(set.workout_id);
-    
-    // Track rest times for analytics
-    if (set.rest_time && set.rest_time > 0) {
-      acc[set.exercise_name].rest_times.push(set.rest_time);
-    }
-    
-    return acc;
-  }, {} as Record<string, { 
-    volume: number; 
-    frequency: number; 
-    total_sets: number;
-    max_weight: number;
-    total_reps: number;
-    workouts_performed: Set<string>;
-    rest_times: number[];
-  }>) || {};
-
-  // Calculate rest time analytics for each exercise
-  const exerciseRestAnalytics = Object.entries(exerciseStats).reduce((acc, [name, stats]) => {
-    if (stats.rest_times.length > 0) {
-      const avgRestTime = stats.rest_times.reduce((sum, time) => sum + time, 0) / stats.rest_times.length;
-      const minRestTime = Math.min(...stats.rest_times);
-      const maxRestTime = Math.max(...stats.rest_times);
-      acc[name] = {
-        average_rest: Math.round(avgRestTime),
-        min_rest: minRestTime,
-        max_rest: maxRestTime,
-        rest_consistency: stats.rest_times.length > 1 ? 
-          Math.round(stats.rest_times.reduce((variance, time) => {
-            const diff = time - avgRestTime;
-            return variance + (diff * diff);
-          }, 0) / stats.rest_times.length) : 0
-      };
-    }
-    return acc;
-  }, {} as Record<string, { average_rest: number; min_rest: number; max_rest: number; rest_consistency: number }>);
-
-  // Convert sets to arrays for serialization
-  const topExercises = Object.entries(exerciseStats)
-    .map(([name, stats]) => ({ 
-      name, 
-      volume: stats.volume,
-      frequency: stats.frequency,
-      total_sets: stats.total_sets,
-      max_weight: stats.max_weight,
-      total_reps: stats.total_reps,
-      workouts_performed: stats.workouts_performed.size,
-      average_rest_time: exerciseRestAnalytics[name]?.average_rest || null
-    }))
-    .sort((a, b) => b.volume - a.volume)
-    .slice(0, 10);
-
-  return {
-    totalWorkouts,
-    totalVolume,
-    totalSets,
-    recentWorkouts: detailedWorkouts.slice(0, 10), // Include detailed exercise data
-    allWorkouts: detailedWorkouts, // Full workout history for analysis
-    topExercises,
-    personalRecords: personalRecords || [],
-    exerciseBreakdown: exerciseStats, // Detailed exercise statistics
-    restAnalytics: exerciseRestAnalytics // Rest time analytics per exercise
-  };
-}
-
 function formatTrainingDataForAI(data: any): string {
+  const earliest = data.earliestSessionUTC
+    ? formatLocalDate(data.earliestSessionUTC)
+    : 'N/A';
   return `
 RECENT PERFORMANCE SUMMARY:
-- Total Workouts (3 months): ${data.totalWorkouts}
+- Earliest Workout: ${earliest}
+- Total Workouts: ${data.totalWorkouts}
 - Total Volume: ${data.totalVolume.toFixed(1)}kg
 - Total Sets: ${data.totalSets}
 
@@ -365,13 +209,13 @@ ${Object.entries(data.restAnalytics || {}).slice(0, 8).map(([exercise, analytics
 ).join('\n')}
 
 RECENT PERSONAL RECORDS:
-${data.personalRecords.slice(0, 5).map((pr: any) => 
-  `- ${pr.exercise_name}: ${pr.value}${pr.unit} (${new Date(pr.date).toLocaleDateString()})`
+${data.personalRecords.slice(0, 5).map((pr: any) =>
+  `- ${pr.exercise_name}: ${pr.value}${pr.unit} (${formatLocalDate(pr.date)})`
 ).join('\n')}
 
 DETAILED RECENT WORKOUT SESSIONS:
 ${data.recentWorkouts.slice(0, 5).map((w: any) => {
-  const workoutDate = new Date(w.start_time).toLocaleDateString();
+  const workoutDate = formatLocalDate(w.start_time);
   const exerciseDetails = w.exercises.map((ex: any) => {
     const completedSets = ex.sets.filter((set: any) => set.completed);
     const setDetails = completedSets.map((set: any) => 

--- a/supabase/tests/rls.test.js
+++ b/supabase/tests/rls.test.js
@@ -1,0 +1,39 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { createClient } from '@supabase/supabase-js';
+
+const url = process.env.SUPABASE_URL;
+const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const anonKey = process.env.SUPABASE_ANON_KEY;
+const testUser = process.env.TEST_USER_ID;
+
+if (!url || !serviceKey || !anonKey || !testUser) {
+  test.skip('RLS tests skipped due to missing env vars', () => {});
+} else {
+  const admin = createClient(url, serviceKey);
+  const anon = createClient(url, anonKey);
+
+  test('service role can read all user rows', async () => {
+    const { data, error } = await admin
+      .from('workout_sessions')
+      .select('id')
+      .eq('user_id', testUser);
+    assert.ifError(error);
+    const count = data.length;
+    const { count: exactCount, error: countErr } = await admin
+      .from('workout_sessions')
+      .select('id', { count: 'exact', head: true })
+      .eq('user_id', testUser);
+    assert.ifError(countErr);
+    assert.equal(count, exactCount);
+  });
+
+  test('anon role is restricted by RLS', async () => {
+    const { data, error } = await anon
+      .from('workout_sessions')
+      .select('id')
+      .eq('user_id', testUser);
+    assert.ifError(error);
+    assert.equal(data.length, 0);
+  });
+}


### PR DESCRIPTION
## Summary
- add reusable `fetchTrainingData` with keyset pagination and earliest-session telemetry
- expose new `ai-training-data` edge endpoint and wire AI coach + client service to use it
- add Europe/Warsaw date formatting helper and integration tests for RLS

## Testing
- `npm run lint` *(fails: Unexpected any / require imports)*
- `node --test supabase/tests/rls.test.js` *(skipped: missing SUPABASE_URL and keys)*

------
https://chatgpt.com/codex/tasks/task_e_68a6235c8b40832699640d244182040f