### PR TITLE
Harden home screen for mobile use

### DIFF
--- a/src/components/MotivationCard.tsx
+++ b/src/components/MotivationCard.tsx
@@ -78,33 +78,37 @@ export const MotivationCard: React.FC<MotivationCardProps> = ({
               <Skeleton className="h-5 w-16 rounded-full" />
             </div>
           ) : (
-            <div className="flex items-center gap-2" aria-live="polite">
-              <span className="text-2xl font-semibold tabular-nums text-white">
-                {tonnage.toLocaleString(locale)}
-              </span>
-              <span className="text-sm font-normal text-white/80 ml-1">kg</span>
-              {tonnage > 0 && equivalence && (
-                <span className="text-xs px-2 py-0.5 rounded-full bg-white/10 text-white/90">
-                  ≈ {equivalence.n.toLocaleString(locale)} {equivalence.label}
-                  {equivalence.n > 1 ? 's' : ''} {equivalence.emoji}
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center" aria-live="polite">
+              <div className="flex items-baseline gap-1">
+                <span className="text-[clamp(22px,7vw,28px)] leading-tight tabular-nums font-semibold text-white">
+                  {tonnage.toLocaleString(locale)}
                 </span>
-              )}
-              {tonnage > 0 && (
-                <span className={cn("text-[10px] px-1.5 py-0.5 rounded-full border", trendClasses)}>
-                  {trendSymbol === '—' ? '—' : `${trendSymbol} ${Math.abs(trend)}%`}
-                </span>
-              )}
+                <span className="text-sm text-white/80">kg</span>
+              </div>
+              <div className="flex items-center gap-2">
+                {tonnage > 0 && equivalence && (
+                  <span className="max-w-[60%] truncate whitespace-nowrap text-xs px-2 py-0.5 rounded-full bg-white/10 text-white/90">
+                    ≈ {equivalence.n.toLocaleString(locale)} {equivalence.label}
+                    {equivalence.n > 1 ? 's' : ''} {equivalence.emoji}
+                  </span>
+                )}
+                {tonnage > 0 && (
+                  <span className={cn("text-[10px] px-1.5 py-0.5 rounded-full border", trendClasses)}>
+                    {trendSymbol === '—' ? '—' : `${trendSymbol} ${Math.abs(trend)}%`}
+                  </span>
+                )}
+              </div>
             </div>
           )}
           {loadingCoach ? (
             <Skeleton className="h-4 w-3/5 mt-1" />
           ) : (
-            <p className="text-sm text-[#9AA3B2] mt-1 line-clamp-2">
+            <p className="mt-1 text-[13px] leading-snug text-white/80 line-clamp-2">
               {tonnage === 0 ? 'Keep lifting—every rep counts.' : coachCopy}
             </p>
           )}
         </div>
-        <div className="flex items-center gap-2 self-center">
+        <div className="ml-auto sm:ml-0 shrink-0 flex items-center gap-1">
           {tonnage > 0 && equivalence && (
             <TooltipProvider>
               <Tooltip>

--- a/src/components/WeeklySummaryStats.tsx
+++ b/src/components/WeeklySummaryStats.tsx
@@ -104,49 +104,41 @@ const StatCard: React.FC<StatCardProps> = ({
   };
 
   return (
-    <div 
-      className="p-4 rounded-xl text-start relative overflow-hidden group transition-all duration-300 hover:scale-[1.02] active:scale-[0.98] cursor-pointer"
+    <div
+      className="p-3 sm:p-4 rounded-xl text-start relative overflow-hidden group transition-all duration-300 hover:scale-[1.02] active:scale-[0.98] cursor-pointer"
       style={cardStyle}
     >
-      {/* Progress indicator for early week */}
-      {comparison.message?.includes('vs last') && comparison.percentage > 0 && (
-        <div className="absolute top-0 right-0 px-2 py-1 bg-green-500/10 rounded-bl-lg">
-          <span className="text-xs text-green-400">On track! 🎯</span>
-        </div>
-      )}
-      
-      <div 
+      <div
         className="absolute inset-0 rounded-xl opacity-50"
         style={innerHighlightStyle}
       />
-      
+
       <div className="relative z-10">
-        <div className="flex items-start justify-between mb-2">
-          <div className="flex items-center">
-            <div className="p-2 bg-zinc-800/50 rounded-lg mr-2">
-              {icon}
-            </div>
-            <span className="text-sm text-muted-foreground">{title}</span>
+        <div className="flex items-center gap-2 min-w-0 mb-2">
+          <div className="p-2 bg-zinc-800/50 rounded-lg">
+            {icon}
           </div>
-          {!isLoading && (
-            <div className={`text-sm font-medium ${comparison.color}`}>
-              {comparison.label}
-            </div>
+          <span className="text-sm truncate text-muted-foreground">{title}</span>
+          {comparison.message?.includes('vs last') && comparison.percentage > 0 && (
+            <span className="ml-auto shrink-0 text-[10px] px-1.5 py-0.5 rounded-full bg-emerald-500/10 text-emerald-400">
+              On track!
+            </span>
           )}
         </div>
-        
+
         <div className="space-y-1">
-          <p className="text-2xl font-bold text-white">
+          <p className="text-xl sm:text-2xl font-semibold tabular-nums text-white">
             {isLoading ? "..." : value}
-            {unit && <span className="text-sm text-zinc-400 ml-1">{unit}</span>}
+            {unit && <span className="text-sm text-white/80 ml-1">{unit}</span>}
           </p>
-          
-          {/* Contextual message */}
-          {comparison.message && !isLoading && (
-            <p className="text-xs text-zinc-500">{comparison.message}</p>
+
+          {!isLoading && (
+            <p className="text-xs text-white/70 leading-snug">
+              {comparison.label}
+              {comparison.message ? ` ${comparison.message}` : ''}
+            </p>
           )}
-          
-          {/* Encouragement for specific situations */}
+
           {encouragement && !isLoading && (
             <p className="text-xs text-purple-400 mt-2">{encouragement}</p>
           )}
@@ -171,9 +163,9 @@ const WeekProgressBar: React.FC<{ currentDay: number }> = ({ currentDay }) => {
 
   return (
     <div className="p-4 rounded-xl mb-4" style={cardStyle}>
-      <div className="flex items-center justify-between mb-3">
-        <h3 className="text-sm font-medium text-zinc-400">Week Progress</h3>
-        <span className="text-xs text-purple-400">
+      <div className="flex items-center gap-2 min-w-0 mb-3">
+        <h3 className="text-sm text-white/90 truncate">Week Progress</h3>
+        <span className="text-xs text-white/70 ml-auto shrink-0">
           Day {currentDay} of 7
         </span>
       </div>
@@ -395,7 +387,7 @@ export const WeeklySummaryStats = React.memo(() => {
         </div>
 
         {/* Stats Grid */}
-        <div className="mt-4 grid grid-cols-2 gap-3">
+        <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
           <StatCard
             icon={<Calendar className="w-4 h-4 text-purple-400" />}
             title="Workouts"

--- a/src/components/training/StartTrainingButton.tsx
+++ b/src/components/training/StartTrainingButton.tsx
@@ -78,7 +78,6 @@ export const StartTrainingButton = ({
   
   return (
     <div className="py-8 px-6"> {/* Premium spacing container */}
-      <style>{`@media (prefers-reduced-motion: reduce) { .ring-animate { animation: none !important; transition: none !important; } }`}</style>
       <div
         onClick={handleStartClick}
         onTouchStart={handleTouchStart}

--- a/src/index.css
+++ b/src/index.css
@@ -79,3 +79,10 @@
     padding-bottom: env(safe-area-inset-bottom);
   }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .ring-animate {
+    animation: none !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
- Stack MotivationCard metrics and chips vertically with responsive text and truncate long equivalence labels
- Clean up WeeklySummaryStats layout: safe Week Progress header, single-column mobile grid, and inline status pill
- Move reduced-motion styles to global CSS and keep StartTrainingButton accessible

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any ... 282 problems)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a71862c7bc8326a52d7c90d8beaafb