### PR TITLE
feat: rotate motivational equivalences

### DIFF
--- a/src/components/MotivationCard.tsx
+++ b/src/components/MotivationCard.tsx
@@ -22,21 +22,32 @@ interface Equivalence {
   fact: string;
 }
 
-const EQUIVALENTS: Equivalence[] = [
-  { weight: 70, label: "person", emoji: "🧍", fact: "An average person weighs about 70 kg." },
-  { weight: 400, label: "grand piano", emoji: "🎹", fact: "A grand piano weighs roughly 400 kg." },
-  { weight: 500, label: "minotaur", emoji: "🐂", fact: "In Greek myth, the labyrinth's Minotaur might tip the scales at around 500 kg." },
-  { weight: 1000, label: "small car", emoji: "🚗", fact: "A small car weighs around 1,000 kg." },
-  { weight: 2500, label: "pyramid stone", emoji: "🪨", fact: "A stone block from the Great Pyramid weighs about 2,500 kg." },
-  { weight: 3000, label: "hippopotamus", emoji: "🦛", fact: "A hippo can weigh about 3,000 kg." },
-  { weight: 6000, label: "elephant", emoji: "🐘", fact: "An African elephant weighs around 6,000 kg." },
-  { weight: 150000, label: "blue whale", emoji: "🐋", fact: "The blue whale, Earth's largest animal, can weigh up to 150,000 kg." },
-  { weight: 300000, label: "Ishtar Gate", emoji: "🏛️", fact: "Babylon's legendary Ishtar Gate is estimated to have weighed around 300,000 kg." },
-];
+const EQUIVALENCE_THEMES: Record<string, Equivalence[]> = {
+  classic: [
+    { weight: 70, label: "person", emoji: "🧍", fact: "An average person weighs about 70 kg." },
+    { weight: 400, label: "grand piano", emoji: "🎹", fact: "A grand piano weighs roughly 400 kg." },
+    { weight: 500, label: "minotaur", emoji: "🐂", fact: "In Greek myth, the labyrinth's Minotaur might tip the scales at around 500 kg." },
+    { weight: 1000, label: "small car", emoji: "🚗", fact: "A small car weighs around 1,000 kg." },
+    { weight: 2500, label: "pyramid stone", emoji: "🪨", fact: "A stone block from the Great Pyramid weighs about 2,500 kg." },
+    { weight: 3000, label: "hippopotamus", emoji: "🦛", fact: "A hippo can weigh about 3,000 kg." },
+    { weight: 6000, label: "elephant", emoji: "🐘", fact: "An African elephant weighs around 6,000 kg." },
+    { weight: 150000, label: "blue whale", emoji: "🐋", fact: "The blue whale, Earth's largest animal, can weigh up to 150,000 kg." },
+    { weight: 300000, label: "Ishtar Gate", emoji: "🏛️", fact: "Babylon's legendary Ishtar Gate is estimated to have weighed around 300,000 kg." },
+  ],
+};
 
-function getEquivalence(tonnage: number) {
+let rotationIndex = 0;
+
+function getEquivalence(
+  tonnage: number,
+  theme: keyof typeof EQUIVALENCE_THEMES = "classic",
+) {
   if (tonnage <= 0) return null;
-  const eq = [...EQUIVALENTS].reverse().find(item => tonnage / item.weight >= 1) || EQUIVALENTS[0];
+  const equivalents = EQUIVALENCE_THEMES[theme] ?? EQUIVALENCE_THEMES.classic;
+  const eligible = equivalents.filter(item => tonnage / item.weight >= 1);
+  const eq = eligible.length
+    ? eligible[rotationIndex++ % eligible.length]
+    : equivalents[0];
   const n = Math.round(tonnage / eq.weight);
   return { ...eq, n };
 }


### PR DESCRIPTION
## Summary
- rotate between multiple tonnage equivalences instead of always picking the heaviest
- group equivalence data by theme to enable future themed comparisons

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any errors and forbidden require imports in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68ab03fb08b8832682df78ad1da1bf33