### PR TITLE
feat: show previous exercise session

### DIFF
--- a/src/components/exercises/WorkoutExerciseCard.tsx
+++ b/src/components/exercises/WorkoutExerciseCard.tsx
@@ -1,7 +1,6 @@
 
 import React from 'react';
 import { Card, CardContent } from "@/components/ui/card";
-import { ExerciseCardHeader } from './ExerciseCardHeader';
 import { SetsList } from './SetsList';
 import { ExerciseVolumeMetrics } from './ExerciseVolumeMetrics';
 import { ExerciseActions } from './ExerciseActions';
@@ -62,7 +61,7 @@ export const WorkoutExerciseCard: React.FC<WorkoutExerciseCardProps> = (props) =
     currentVolume,
     previousVolume,
     volumeMetrics,
-    progressData
+    loadingPreviousSession
   } = useExerciseCard(exercise, sets);
 
   // Extract variant information for enhanced display
@@ -130,13 +129,17 @@ export const WorkoutExerciseCard: React.FC<WorkoutExerciseCardProps> = (props) =
                 </div>
               )}
               
-              {previousSession && (
+              {loadingPreviousSession ? (
+                <p className="text-sm text-gray-400">Loading last session…</p>
+              ) : previousSession ? (
                 <p className="text-sm text-gray-400">
                   Last session:{' '}
                   <span className="text-gray-300 font-mono">
                     {previousSession.weight} kg × {previousSession.reps} × {previousSession.sets}
                   </span>
                 </p>
+              ) : (
+                <p className="text-sm text-gray-400">No previous session</p>
               )}
             </div>
             

--- a/src/components/exercises/hooks/useExerciseCard.ts
+++ b/src/components/exercises/hooks/useExerciseCard.ts
@@ -1,101 +1,105 @@
-
-import { useMemo } from 'react';
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+import { useAuth } from "@/context/AuthContext";
 import { useWeightUnit } from "@/context/WeightUnitContext";
 import { convertWeight } from "@/utils/unitConversion";
-import { ExerciseSet } from '@/types/workout-enhanced';
+import { ExerciseSet } from "@/types/workout-enhanced";
 
-// Sample exercise history data - in real app this would come from API
-const exerciseHistoryData: Record<string, Array<{
-  date: string;
+interface PreviousSessionData {
   weight: number;
   reps: number;
   sets: number;
-  exerciseGroup?: string;
-}>> = {
-  "Bench Press": [
-    { date: "Apr 10", weight: 135, reps: 10, sets: 3, exerciseGroup: "chest" },
-    { date: "Apr 3", weight: 130, reps: 10, sets: 3, exerciseGroup: "chest" },
-    { date: "Mar 27", weight: 125, reps: 8, sets: 3, exerciseGroup: "chest" },
-  ],
-  "Squats": [
-    { date: "Apr 9", weight: 185, reps: 8, sets: 3, exerciseGroup: "legs" },
-    { date: "Apr 2", weight: 175, reps: 8, sets: 3, exerciseGroup: "legs" },
-    { date: "Mar 26", weight: 165, reps: 8, sets: 3, exerciseGroup: "legs" },
-  ],
-  "Deadlift": [
-    { date: "Apr 8", weight: 225, reps: 5, sets: 3, exerciseGroup: "back" },
-    { date: "Apr 1", weight: 215, reps: 5, sets: 3, exerciseGroup: "back" },
-    { date: "Mar 25", weight: 205, reps: 5, sets: 3, exerciseGroup: "back" },
-  ],
-  "Pull-ups": [
-    { date: "Apr 7", weight: 0, reps: 8, sets: 3, exerciseGroup: "back" },
-    { date: "Mar 31", weight: 0, reps: 7, sets: 3, exerciseGroup: "back" },
-    { date: "Mar 24", weight: 0, reps: 6, sets: 3, exerciseGroup: "back" },
-  ],
-};
+}
+
+export type PreviousSession = PreviousSessionData | null;
 
 export const useExerciseCard = (exerciseName: string, sets: ExerciseSet[]) => {
+  const { user } = useAuth();
   const { weightUnit } = useWeightUnit();
 
-  const previousSession = useMemo(() => {
-    const history = exerciseHistoryData[exerciseName] || [];
-    if (history.length > 0) {
-      return history[0];
-    }
-    return { date: "N/A", weight: 0, reps: 0, sets: 0, exerciseGroup: "" };
-  }, [exerciseName]);
+  const {
+    data: previousSession,
+    isLoading: loadingPreviousSession,
+  } = useQuery<PreviousSession>({
+    queryKey: ["previous-session", user?.id, exerciseName, weightUnit],
+    enabled: !!user && !!exerciseName,
+    queryFn: async () => {
+      if (!user) return null;
 
-  const olderSession = useMemo(() => {
-    const history = exerciseHistoryData[exerciseName] || [];
-    return history[1] || previousSession;
-  }, [exerciseName, previousSession]);
+      const { data, error } = await supabase
+        .from("exercise_sets")
+        .select(
+          "weight, reps, workout_id, set_number, workout_sessions!inner(start_time, user_id)"
+        )
+        .eq("exercise_name", exerciseName)
+        .eq("workout_sessions.user_id", user.id)
+        .order("workout_sessions.start_time", {
+          foreignTable: "workout_sessions",
+          ascending: false,
+        })
+        .order("set_number", { ascending: true })
+        .limit(1);
 
-  const progressData = useMemo(() => {
-    const weightDiff = previousSession.weight - olderSession.weight;
-    const percentChange = olderSession.weight ? ((weightDiff / olderSession.weight) * 100).toFixed(1) : "0";
-    const isImproved = weightDiff > 0;
+      if (error) throw error;
+      if (!data || data.length === 0) return null;
 
-    return {
-      weightDiff,
-      percentChange,
-      isImproved
-    };
-  }, [previousSession, olderSession]);
+      const latestSet = data[0];
+
+      const { count, error: countError } = await supabase
+        .from("exercise_sets")
+        .select("id", { count: "exact", head: true })
+        .eq("exercise_name", exerciseName)
+        .eq("workout_id", latestSet.workout_id);
+
+      if (countError) throw countError;
+
+      return {
+        weight: convertWeight(latestSet.weight, "kg", weightUnit),
+        reps: latestSet.reps,
+        sets: count ?? 1,
+      };
+    },
+  });
 
   const currentVolume = useMemo(() => {
     return sets.reduce((total, set) => {
       if (set.completed && set.weight > 0 && set.reps > 0) {
-        return total + (set.weight * set.reps);
+        return total + set.weight * set.reps;
       }
       return total;
     }, 0);
   }, [sets]);
 
   const previousVolume = useMemo(() => {
-    return previousSession.weight > 0 ? 
-      (convertWeight(previousSession.weight, "lb", weightUnit) * previousSession.reps * previousSession.sets) : 0;
-  }, [previousSession, weightUnit]);
+    if (!previousSession) return 0;
+    return previousSession.weight * previousSession.reps * previousSession.sets;
+  }, [previousSession]);
 
   const volumeMetrics = useMemo(() => {
-    const volumeDiff = currentVolume > 0 && previousVolume > 0 ? (currentVolume - previousVolume) : 0;
-    const volumePercentChange = previousVolume > 0 ? ((volumeDiff / previousVolume) * 100).toFixed(1) : "0";
-    const hasValidComparison = previousSession.exerciseGroup && previousVolume > 0;
+    const volumeDiff =
+      currentVolume > 0 && previousVolume > 0
+        ? currentVolume - previousVolume
+        : 0;
+    const volumePercentChange =
+      previousVolume > 0
+        ? ((volumeDiff / previousVolume) * 100).toFixed(1)
+        : "0";
+    const hasValidComparison = previousSession !== null && previousVolume > 0;
 
     return {
       volumeDiff,
       volumePercentChange,
-      hasValidComparison
+      hasValidComparison,
     };
   }, [currentVolume, previousVolume, previousSession]);
 
   return {
-    previousSession: {
-      ...previousSession,
-      weight: convertWeight(previousSession.weight, "lb", weightUnit)
-    },
+    previousSession,
     currentVolume,
     previousVolume,
     volumeMetrics,
-    progressData
+    loadingPreviousSession,
   };
 };
+


### PR DESCRIPTION
## Summary
- query Supabase for last exercise session and summarize weight/reps/sets
- show loading and no-session states on workout exercise card

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac89ecfb508326ba2a9e791bfb4d48