### PR TITLE
feat: integrate unified exercise library

### DIFF
--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from 'react';
+
+export function useDebounce<T>(value: T, delay: number) {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(handler);
+  }, [value, delay]);
+
+  return debounced;
+}


### PR DESCRIPTION
## Summary
- replace Add Exercise preview with direct Exercise Library picker
- add Suggested/Recent/All tabs with debounced search and manual list virtualization
- track exercise_add analytics and expose reusable debounce hook

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 299 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8ac3676c8326a9c0cd09bd76b15e