### PR TITLE
Exercise Library: fix list overlap and restore grid scrolling

### DIFF
--- a/src/components/ui/AppBackground.tsx
+++ b/src/components/ui/AppBackground.tsx
@@ -5,12 +5,18 @@ interface AppBackgroundProps {
   children: React.ReactNode;
   variant?: 'primary' | 'secondary' | 'minimal';
   className?: string;
+  /**
+   * When true, prevents enforcing a full screen height.
+   * Useful when rendering inside constrained containers like sheets.
+   */
+  noMinHeight?: boolean;
 }
 
-export function AppBackground({ 
-  children, 
-  variant = 'primary', 
-  className 
+export function AppBackground({
+  children,
+  variant = 'primary',
+  className,
+  noMinHeight = false
 }: AppBackgroundProps) {
   const getBackgroundStyles = () => {
     switch (variant) {
@@ -26,9 +32,10 @@ export function AppBackground({
   };
 
   return (
-    <div 
+    <div
       className={cn(
-        'min-h-screen w-full',
+        !noMinHeight && 'min-h-screen',
+        'w-full',
         getBackgroundStyles(),
         className
       )}


### PR DESCRIPTION
## Summary
- remove custom virtualization and render simple scrollable list
- allow AppBackground to opt-out of `min-h-screen` for embedded views
- restructure Exercise Library containers so only the list scrolls

## Testing
- `npm run lint` *(fails: Unexpected any...)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac94c3ce488326836852d89094227d