### PR TITLE
feat: normalize exercise metadata

### DIFF
--- a/src/components/exercises/EnhancedExerciseCard.tsx
+++ b/src/components/exercises/EnhancedExerciseCard.tsx
@@ -378,19 +378,34 @@ export function EnhancedExerciseCard({
               </div>
             )}
 
-            {/* Metadata */}
-            {exercise.metadata && Object.keys(exercise.metadata).length > 0 && (
-              <div>
-                <h4 className="text-sm font-medium mb-2">Additional Info</h4>
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm text-muted-foreground">
-                  {typeof exercise.metadata === 'object' && Object.entries(exercise.metadata).map(([key, value]) => (
-                    <div key={key}>
-                      <span className="font-medium capitalize">{key.replace(/_/g, ' ')}:</span> {String(value)}
-                    </div>
-                  ))}
+            {/* Normalized fields */}
+            <div>
+              <h4 className="text-sm font-medium mb-2">Additional Info</h4>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm text-muted-foreground">
+                <div>
+                  <span className="font-medium">Type:</span> {exercise.type}
                 </div>
+                <div>
+                  <span className="font-medium">Bodyweight:</span>{' '}
+                  {exercise.is_bodyweight ? 'Yes' : 'No'}
+                </div>
+                {exercise.bw_multiplier != null && (
+                  <div>
+                    <span className="font-medium">BW Multiplier:</span> {exercise.bw_multiplier}
+                  </div>
+                )}
+                {exercise.static_posture_factor != null && (
+                  <div>
+                    <span className="font-medium">Static Posture:</span> {exercise.static_posture_factor}
+                  </div>
+                )}
+                {exercise.energy_cost_factor != null && (
+                  <div>
+                    <span className="font-medium">Energy Cost:</span> {exercise.energy_cost_factor}
+                  </div>
+                )}
               </div>
-            )}
+            </div>
           </div>
         )}
 

--- a/src/components/exercises/ExerciseDetailsModal.tsx
+++ b/src/components/exercises/ExerciseDetailsModal.tsx
@@ -247,20 +247,38 @@ export function ExerciseDetailsModal({
             </div>
           )}
 
-          {/* Metadata */}
-          {exercise.metadata && Object.keys(exercise.metadata).length > 0 && (
-            <div>
-              <h4 className="text-sm font-semibold mb-3">Additional Information</h4>
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                {typeof exercise.metadata === 'object' && Object.entries(exercise.metadata).map(([key, value]) => (
-                  <div key={key} className="flex justify-between p-2 rounded bg-muted/30">
-                    <span className="font-medium capitalize text-sm">{key.replace(/_/g, ' ')}:</span>
-                    <span className="text-sm text-muted-foreground">{String(value)}</span>
-                  </div>
-                ))}
+          {/* Normalized fields */}
+          <div>
+            <h4 className="text-sm font-semibold mb-3">Additional Information</h4>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div className="flex justify-between p-2 rounded bg-muted/30">
+                <span className="font-medium text-sm">Type:</span>
+                <span className="text-sm text-muted-foreground">{exercise.type}</span>
               </div>
+              <div className="flex justify-between p-2 rounded bg-muted/30">
+                <span className="font-medium text-sm">Bodyweight:</span>
+                <span className="text-sm text-muted-foreground">{exercise.is_bodyweight ? 'Yes' : 'No'}</span>
+              </div>
+              {exercise.bw_multiplier != null && (
+                <div className="flex justify-between p-2 rounded bg-muted/30">
+                  <span className="font-medium text-sm">BW Multiplier:</span>
+                  <span className="text-sm text-muted-foreground">{exercise.bw_multiplier}</span>
+                </div>
+              )}
+              {exercise.static_posture_factor != null && (
+                <div className="flex justify-between p-2 rounded bg-muted/30">
+                  <span className="font-medium text-sm">Static Posture:</span>
+                  <span className="text-sm text-muted-foreground">{exercise.static_posture_factor}</span>
+                </div>
+              )}
+              {exercise.energy_cost_factor != null && (
+                <div className="flex justify-between p-2 rounded bg-muted/30">
+                  <span className="font-medium text-sm">Energy Cost:</span>
+                  <span className="text-sm text-muted-foreground">{exercise.energy_cost_factor}</span>
+                </div>
+              )}
             </div>
-          )}
+          </div>
         </div>
       </DialogContent>
     </Dialog>

--- a/src/hooks/useExerciseWeight.ts
+++ b/src/hooks/useExerciseWeight.ts
@@ -1,6 +1,6 @@
 
 import { useState, useEffect } from 'react';
-import { Exercise, ExerciseSet, WeightCalculation, EXERCISE_LOAD_FACTORS } from '@/types/exercise';
+import { Exercise, ExerciseSet, WeightCalculation } from '@/types/exercise';
 
 interface UseExerciseWeightProps {
   exercise: Exercise;
@@ -16,8 +16,9 @@ export const useExerciseWeight = ({
   const getInitialWeight = (): WeightCalculation => {
     if (!exercise) return { value: defaultWeight, isAuto: false, source: 'default' };
 
-    const isBodyweight = exercise.is_bodyweight || exercise.equipment_type.includes('bodyweight');
-    const loadFactor = exercise.load_factor || EXERCISE_LOAD_FACTORS[exercise.name]?.factor || 1.0;
+    const isBodyweight =
+      exercise.is_bodyweight || exercise.equipment_type.includes('bodyweight');
+    const loadFactor = exercise.bw_multiplier ?? 1.0;
 
     if (isBodyweight && userWeight) {
       return {


### PR DESCRIPTION
## Summary
- add typed exercise metadata fields and new ExerciseType
- parse metadata in useExercises with fallback to legacy load factors
- update components and weight hook to use normalized fields

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac9a00bdec8326ad111832c1293db2