### PR TITLE
fix: consolidate header spacing

### DIFF
--- a/src/components/layouts/MainLayout.tsx
+++ b/src/components/layouts/MainLayout.tsx
@@ -4,7 +4,6 @@ import { BottomNav } from "@/components/navigation/BottomNav";
 import { PageHeader } from "@/components/navigation/PageHeader";
 import { WorkoutBanner } from "@/components/training/WorkoutBanner";
 import { useLocation } from "react-router-dom";
-import { useLayout } from "@/context/LayoutContext";
 
 import { MainMenu } from "@/components/navigation/MainMenu";
 import { useWorkoutPageVisibility } from "@/store/workoutStore";
@@ -85,7 +84,13 @@ export const MainLayout: React.FC<MainLayoutProps> = ({
         </div>
       )}
       
-      <main className={`flex-grow overflow-y-auto ${shouldShowGlobalHeader ? 'pt-16' : 'pt-0'} pb-16 will-change-transform`}>
+      <main
+        className={`flex-grow overflow-y-auto ${
+          shouldShowGlobalHeader
+            ? 'pt-[var(--header-offset)]'
+            : 'pt-[env(safe-area-inset-top)]'
+        } pb-16 will-change-transform`}
+      >
         <div className="content-container w-full">
           {children}
         </div>

--- a/src/components/navigation/PageHeader.tsx
+++ b/src/components/navigation/PageHeader.tsx
@@ -27,7 +27,10 @@ export const PageHeader: React.FC<PageHeaderProps> = ({
   };
 
   return (
-    <header className="fixed top-0 left-0 right-0 h-16 pt-[env(safe-area-inset-top)] flex items-center px-4 bg-gray-900/95 backdrop-blur-sm z-10 border-b border-gray-800/50">
+    <header
+      className="fixed left-0 right-0 h-[var(--header-h)] flex items-center px-4 bg-gray-900/95 backdrop-blur-sm z-10 border-b border-gray-800/50"
+      style={{ top: "env(safe-area-inset-top)" }}
+    >
       <div className="flex-1 flex items-center min-w-0">
         {showBackButton && (
           <button onClick={handleBack} className="mr-2 p-2 -ml-2">

--- a/src/index.css
+++ b/src/index.css
@@ -60,6 +60,8 @@
     --input: 240 3.7% 15.9%;
     --ring: 240 4.9% 83.9%;
     --radius: 0.75rem;
+    --header-h: 4rem;
+    --header-offset: calc(var(--header-h) + env(safe-area-inset-top));
   }
   .glass,
   .card-gradient {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -137,7 +137,7 @@ const Index = () => {
 
   return (
     <AppBackground variant="primary" className="flex flex-col">
-      <main className="flex-1 overflow-auto px-4 py-6 mt-12 pb-20">
+      <div className="flex-1 overflow-auto px-4 pb-20">
 
         {/* <DateRangeProvider>
           <QuickStatsSection />
@@ -146,11 +146,7 @@ const Index = () => {
         {/* HERO */}
         <section
           ref={sectionRef}
-          className="
-            relative isolate z-0
-            pt-[calc(env(safe-area-inset-top)+8px)]
-            pb-0
-          "
+          className="relative isolate z-0 mt-6"
           style={{
             "--ring-d": "clamp(200px,58vw,288px)",
             "--glow-pad": "clamp(56px,12vw,88px)"
@@ -207,7 +203,7 @@ const Index = () => {
         <div className="mt-6">
           <ExploreSection />
         </div>
-      </main>
+      </div>
 
       <EnhancedWorkoutSetupWizard
         open={wizardOpen}


### PR DESCRIPTION
## Summary
- normalize header spacing by using CSS variables for header height and safe-area
- remove extra padding and nested `<main>` from Home page hero
- shift global header below device safe area

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install vitest` *(fails: 403 Forbidden @testing-library/jest-dom)*
- `npm run lint` *(fails: 273 errors, 43 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68acad3333dc8326b45d4fe62e7b1290