### PR TITLE
Add structured workout service modules with shared types

### DIFF
--- a/src/services/workout/index.ts
+++ b/src/services/workout/index.ts
@@ -1,0 +1,4 @@
+export { workoutDataService } from './workoutDataService';
+export { workoutCalculationService } from './workoutCalculationService';
+export { workoutValidationService } from './workoutValidationService';
+export { workoutSaveService } from './workoutSaveService';

--- a/src/services/workout/types/index.ts
+++ b/src/services/workout/types/index.ts
@@ -1,0 +1,1 @@
+export * from './workoutService.types';

--- a/src/services/workout/types/workoutService.types.ts
+++ b/src/services/workout/types/workoutService.types.ts
@@ -1,0 +1,41 @@
+import { EnhancedExerciseSet, WorkoutError, SaveProgress } from '@/types/workout';
+
+export interface SaveWorkoutParams {
+  userData: {
+    id: string;
+    [key: string]: any;
+  };
+  workoutData: {
+    name: string;
+    training_type: string;
+    start_time: string;
+    end_time: string;
+    duration: number;
+    notes: string | null;
+    metadata: any;
+  };
+  exercises: Record<string, EnhancedExerciseSet[]>;
+  onProgressUpdate?: (progress: SaveProgress) => void;
+}
+
+export interface SaveResult {
+  success: boolean;
+  workoutId?: string;
+  error?: WorkoutError;
+  partialSave?: boolean;
+}
+
+export interface WorkoutUpdateData {
+  name?: string;
+  training_type?: string;
+  start_time?: string;
+  end_time?: string;
+  duration?: number;
+  notes?: string | null;
+}
+
+export interface WorkoutBulkUpdateData {
+  name?: string;
+  training_type?: string;
+  notes?: string | null;
+}

--- a/src/services/workout/workoutCalculationService.ts
+++ b/src/services/workout/workoutCalculationService.ts
@@ -1,0 +1,16 @@
+import { processWorkoutMetrics } from '@/utils/workoutMetricsProcessor';
+import { ExerciseSet } from '@/types/exercise';
+
+export class WorkoutCalculationService {
+  processMetrics(
+    exercises: Record<string, ExerciseSet[]>,
+    duration: number,
+    weightUnit: 'kg' | 'lb' = 'kg',
+    userBodyInfo?: { weight: number; unit: string },
+    workoutTiming?: { start_time?: string; duration: number }
+  ) {
+    return processWorkoutMetrics(exercises, duration, weightUnit, userBodyInfo, workoutTiming);
+  }
+}
+
+export const workoutCalculationService = new WorkoutCalculationService();

--- a/src/services/workout/workoutDataService.ts
+++ b/src/services/workout/workoutDataService.ts
@@ -1,0 +1,26 @@
+import { updateWorkout, getWorkoutWithExercises, deleteWorkout, bulkDeleteWorkouts, bulkUpdateWorkouts } from '../workoutManagementService';
+import { WorkoutUpdateData, WorkoutBulkUpdateData } from './types';
+
+export class WorkoutDataService {
+  getWorkout(workoutId: string) {
+    return getWorkoutWithExercises(workoutId);
+  }
+
+  updateWorkout(workoutId: string, data: WorkoutUpdateData) {
+    return updateWorkout(workoutId, data);
+  }
+
+  deleteWorkout(workoutId: string) {
+    return deleteWorkout(workoutId);
+  }
+
+  bulkDelete(workoutIds: string[]) {
+    return bulkDeleteWorkouts(workoutIds);
+  }
+
+  bulkUpdate(workoutIds: string[], data: WorkoutBulkUpdateData) {
+    return bulkUpdateWorkouts(workoutIds, data);
+  }
+}
+
+export const workoutDataService = new WorkoutDataService();

--- a/src/services/workout/workoutSaveService.ts
+++ b/src/services/workout/workoutSaveService.ts
@@ -1,0 +1,22 @@
+import { saveWorkout, processRetryQueue, recoverPartiallyCompletedWorkout, attemptImmediateRecovery } from '../workoutSaveService';
+import { SaveWorkoutParams, SaveResult } from './types';
+
+export class WorkoutSaveService {
+  save(params: SaveWorkoutParams): Promise<SaveResult> {
+    return saveWorkout(params);
+  }
+
+  processQueue(userId: string) {
+    return processRetryQueue(userId);
+  }
+
+  recover(workoutId: string) {
+    return recoverPartiallyCompletedWorkout(workoutId);
+  }
+
+  attemptImmediateRecovery(workoutId: string) {
+    return attemptImmediateRecovery(workoutId);
+  }
+}
+
+export const workoutSaveService = new WorkoutSaveService();

--- a/src/services/workout/workoutValidationService.ts
+++ b/src/services/workout/workoutValidationService.ts
@@ -1,0 +1,9 @@
+import { TimingValidator, TimingReport } from '@/utils/timingValidation';
+
+export class WorkoutValidationService {
+  validateTiming(params: Parameters<typeof TimingValidator.validateWorkoutTiming>[0]): TimingReport {
+    return TimingValidator.validateWorkoutTiming(params);
+  }
+}
+
+export const workoutValidationService = new WorkoutValidationService();


### PR DESCRIPTION
## Summary
- add class-based workout services for data, calculations, validation, and saving
- centralize service exports and shared type definitions

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68acc127270083268e9aae33c4f8f4b9