### PR TITLE
feat: add animated gradient wizard progress

### DIFF
--- a/src/components/training/enhanced/WizardProgress.tsx
+++ b/src/components/training/enhanced/WizardProgress.tsx
@@ -1,4 +1,5 @@
-import { brandColors, componentPatterns } from '@/utils/tokenUtils';
+import { gradients, effects } from '@/utils/tokenUtils';
+import { designTokens } from '@/designTokens';
 
 interface WizardProgressProps {
   currentStep: number;
@@ -11,19 +12,34 @@ export const WizardProgress = ({ currentStep, totalSteps, steps }: WizardProgres
     <div className="flex items-center justify-center mb-6 px-4">
       {steps.map((step, index) => (
         <div key={index} className="flex items-center">
-          <div
-            className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold transition-colors ${
-              index <= currentStep
-                ? `bg-gradient-to-r ${brandColors.gradient()} text-white`
-                : 'bg-zinc-700 text-zinc-400'
-            }`}
-          >
-            {index + 1}
+          <div className="relative flex items-center justify-center">
+            {index === currentStep && (
+              <span
+                aria-hidden="true"
+                className={`absolute -inset-1 rounded-full bg-gradient-to-r ${gradients.brand.primary()} opacity-75 ${effects.glow.subtle()} ${designTokens.animations.pulse.glow}`}
+              />
+            )}
+            <div
+              className={`relative w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold transition-all transform ${
+                index <= currentStep
+                  ? `bg-gradient-to-r ${gradients.brand.primary()} text-white ${effects.glow.subtle()}`
+                  : 'bg-zinc-700 text-zinc-400'
+              } ${index === currentStep ? `${designTokens.animations.pulse.scale} scale-105` : ''}`}
+              aria-current={index === currentStep ? 'step' : undefined}
+            >
+              {index + 1}
+            </div>
           </div>
           {index < totalSteps - 1 && (
-            <div
-              className={`w-12 h-0.5 mx-2 ${index < currentStep ? 'bg-purple-600' : 'bg-zinc-700'}`}
-            />
+            <div className="relative w-12 h-0.5 mx-2 rounded-full bg-zinc-700 overflow-hidden">
+              <div
+                className={`absolute inset-0 transition-all duration-300 ${
+                  index < currentStep
+                    ? `bg-gradient-to-r ${gradients.brand.primary()}`
+                    : 'bg-zinc-700'
+                } ${index < currentStep ? 'w-full' : 'w-0'}`}
+              />
+            </div>
           )}
         </div>
       ))}


### PR DESCRIPTION
## Summary
- animate wizard progress steps with gradient fills and glowing pulse
- add gradient connectors that reflect completion status

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden for @testing-library/jest-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68ad99e71fa083268691fce6047f84bf