### PR TITLE
Add animated transitions and loading overlay to setup wizard

### DIFF
--- a/src/components/training/enhanced/EnhancedWorkoutSetupWizard.tsx
+++ b/src/components/training/enhanced/EnhancedWorkoutSetupWizard.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { TrainingFocusSelector } from './TrainingFocusSelector';
 import {
-  ArrowLeft,
   ArrowUp,
   ArrowDown,
   Dumbbell,
@@ -10,6 +9,7 @@ import {
   Heart,
   Shield,
 } from 'lucide-react';
+import { AnimatePresence, motion } from 'framer-motion';
 import {
   componentPatterns,
   typography,
@@ -25,6 +25,8 @@ import {
   TrainingGoals,
   EnhancedTrainingConfig,
 } from '@/types/training-setup';
+import { BackButton } from '@/components/ui/BackButton';
+import { LoadingOverlay } from '@/components/ui/LoadingOverlay';
 
 // Dev-only feature flag exposure
 if (typeof window !== 'undefined') {
@@ -59,6 +61,27 @@ const FOCUS_ICONS: Record<TrainingFocus['category'], React.ReactNode> = {
   Core: <Heart className="h-5 w-5" />,
   'Deload / Rehab': <Shield className="h-5 w-5" />,
 };
+
+const StepTransition = ({
+  step,
+  children,
+}: {
+  step: number;
+  children: React.ReactNode;
+}) => (
+  <AnimatePresence mode="wait">
+    <motion.div
+      key={step}
+      initial={{ x: 50, opacity: 0 }}
+      animate={{ x: 0, opacity: 1 }}
+      exit={{ x: -50, opacity: 0 }}
+      transition={{ duration: 0.3 }}
+      className="flex flex-col flex-1"
+    >
+      {children}
+    </motion.div>
+  </AnimatePresence>
+);
 
 export function EnhancedWorkoutSetupWizard({
   open,
@@ -204,7 +227,8 @@ export function EnhancedWorkoutSetupWizard({
               { title: 'Start', completed: false },
             ]}
           />
-          {step === 1 ? (
+          <StepTransition step={step}>
+            {step === 1 ? (
             <>
               <div className="flex-shrink-0 pt-6 pb-4">
                 <div className={componentPatterns.modal.header()}>
@@ -231,18 +255,15 @@ export function EnhancedWorkoutSetupWizard({
                 </button>
               </div>
             </>
-          ) : (
-            <>
+            ) : (
+              <>
               <div className="flex-shrink-0 pt-6 pb-4">
                 <div className={componentPatterns.modal.header()}>
                   <div className="flex items-center gap-3">
-                    <button
+                    <BackButton
                       onClick={handleBackToStep1}
-                      className={componentPatterns.button.ghost() + ' p-2'}
                       aria-label="Back to focus selection"
-                    >
-                      <ArrowLeft className="h-4 w-4" />
-                    </button>
+                    />
                     <div>
                       <h2 className={typography.sectionHeading()}>How would you like to start?</h2>
                       <p className={`${typography.bodyText()} text-zinc-400`}>
@@ -280,14 +301,7 @@ export function EnhancedWorkoutSetupWizard({
                     className={`${componentPatterns.cta.primary()} w-full h-14 relative overflow-hidden group flex items-center justify-center disabled:opacity-50 disabled:cursor-not-allowed`}
                     aria-label="Generate Smart Program - auto-build a proven workout plan"
                   >
-                    {isGenerating && (
-                      <div className="absolute inset-0 flex items-center justify-center">
-                        <div className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin" />
-                      </div>
-                    )}
-                    <span className={`relative z-10 ${isGenerating ? 'opacity-0' : ''}`}>
-                      Generate Smart Program
-                    </span>
+                    <span className="relative z-10">Generate Smart Program</span>
                     <div className="absolute inset-0 rounded-full bg-gradient-to-r from-white/20 to-transparent opacity-0 group-hover:opacity-100 transition-opacity" />
                   </button>
 
@@ -311,8 +325,10 @@ export function EnhancedWorkoutSetupWizard({
                   Cancel
                 </button>
               </div>
-            </>
-          )}
+              </>
+            )}
+          </StepTransition>
+          {isGenerating && <LoadingOverlay />}
         </div>
       </div>
     </div>

--- a/src/components/ui/BackButton.tsx
+++ b/src/components/ui/BackButton.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { ArrowLeft } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface BackButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  icon?: React.ReactNode;
+}
+
+export function BackButton({
+  icon = <ArrowLeft className="h-4 w-4" />,
+  className,
+  ...props
+}: BackButtonProps) {
+  return (
+    <button
+      {...props}
+      className={cn(
+        'p-2 rounded-full bg-white/10 text-white backdrop-blur-sm',
+        'transition-transform hover:scale-105 active:scale-95 hover:bg-white/20',
+        className
+      )}
+    >
+      {icon}
+    </button>
+  );
+}
+

--- a/src/components/ui/LoadingOverlay.tsx
+++ b/src/components/ui/LoadingOverlay.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+import { componentPatterns } from '@/utils/tokenUtils';
+
+interface LoadingOverlayProps {
+  message?: string;
+}
+
+export function LoadingOverlay({ message = 'Generating program...' }: LoadingOverlayProps) {
+  return (
+    <div className="absolute inset-0 flex items-center justify-center bg-black/40 backdrop-blur-sm z-50">
+      <div className={cn(componentPatterns.cards.metric(), 'flex flex-col items-center gap-3 pointer-events-none')}>
+        <div className="w-6 h-6 border-2 border-white border-t-transparent rounded-full animate-spin" />
+        {message && <p className="text-sm text-white/80">{message}</p>}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- animate wizard steps with new StepTransition wrapper
- add reusable BackButton with blurred background and scale effects
- show LoadingOverlay during program generation

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68aecd9c170483268586b60bc31b8587