### PR TITLE
Refactor PageHeader with design tokens

### DIFF
--- a/src/components/navigation/PageHeader.tsx
+++ b/src/components/navigation/PageHeader.tsx
@@ -2,19 +2,24 @@
 import React from "react";
 import { ArrowLeft } from "lucide-react";
 import { useNavigate } from "react-router-dom";
+import { surfaceColors, effects, componentPatterns, typography } from "@/utils/tokenUtils";
+import { designTokens } from "@/designTokens";
 
 interface PageHeaderProps {
   title: string;
   showBackButton?: boolean;
   onBack?: () => void;
   children?: React.ReactNode;
+  /** Optional brand gradient for the title text */
+  brandGradient?: boolean;
 }
 
-export const PageHeader: React.FC<PageHeaderProps> = ({ 
-  title, 
-  showBackButton = false, 
+export const PageHeader: React.FC<PageHeaderProps> = ({
+  title,
+  showBackButton = false,
   onBack,
-  children
+  children,
+  brandGradient = false
 }) => {
   const navigate = useNavigate();
   
@@ -28,19 +33,26 @@ export const PageHeader: React.FC<PageHeaderProps> = ({
 
   return (
     <header
-      className="fixed left-0 right-0 h-[var(--header-h)] flex items-center px-4 bg-gray-900/95 backdrop-blur-sm z-10 border-b border-gray-800/50"
+      className={`fixed left-0 right-0 h-[var(--header-h)] flex items-center px-[${designTokens.spacing.lg}] ${surfaceColors.primary()} ${effects.blur.card()} ${effects.elevation.card()} border-b border-white/15 z-10`}
       style={{ top: "env(safe-area-inset-top)" }}
     >
       <div className="flex-1 flex items-center min-w-0">
         {showBackButton && (
-          <button onClick={handleBack} className="mr-2 p-2 -ml-2">
+          <button
+            onClick={handleBack}
+            className={`${componentPatterns.button.secondary()} rounded-full p-[${designTokens.spacing.sm}] aspect-square -ml-[${designTokens.spacing.sm}] mr-[${designTokens.spacing.sm}] transition-all ${designTokens.animations.hover.duration} ${designTokens.animations.hover.easing} hover:${designTokens.animations.hover.scale} hover:${effects.glow.purple()}`}
+          >
             <ArrowLeft size={20} />
           </button>
         )}
-        <h1 className="text-xl font-bold truncate">{title}</h1>
+        <h1
+          className={`${typography.pageHeading()} truncate ${brandGradient ? typography.brandGradient() : ""}`}
+        >
+          {title}
+        </h1>
       </div>
       {children && (
-        <div className="flex items-center ml-2">
+        <div className={`flex items-center ml-[${designTokens.spacing.sm}]`}>
           {children}
         </div>
       )}


### PR DESCRIPTION
## Summary
- replace hard-coded header styles with surface, blur, elevation, and spacing tokens
- wrap back arrow in circular secondary button with animated hover glow
- apply tokenized page heading typography with optional brand gradient

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aed6a549008326a81180c9b42fa63d