### PR TITLE
Refactor typography usage in exercise pages

### DIFF
--- a/src/components/exercises/EnhancedExerciseCard.tsx
+++ b/src/components/exercises/EnhancedExerciseCard.tsx
@@ -197,68 +197,90 @@ export function EnhancedExerciseCard({
       <CardContent className="space-y-4 relative z-10">
         {/* Key Information */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-          <div className="flex items-center gap-2">
-            <Target className="h-4 w-4 text-primary" />
-            <div>
-              <p className="text-xs text-muted-foreground">Primary Muscles</p>
-              <p className="text-sm font-medium">{formatMuscleGroups(exercise.primary_muscle_groups)}</p>
+            <div className="flex items-center gap-2">
+              <Target className="h-4 w-4 text-primary" />
+              <div>
+                <p className={typography.caption()}>Primary Muscles</p>
+                <p className={typography.cardSubtitle()}>
+                  {formatMuscleGroups(exercise.primary_muscle_groups)}
+                </p>
+              </div>
+            </div>
+
+            <div className="flex items-center gap-2">
+              <Dumbbell className="h-4 w-4 text-primary" />
+              <div>
+                <p className={typography.caption()}>Equipment</p>
+                <p className={typography.cardSubtitle()}>
+                  {formatEquipment(exercise.equipment_type)}
+                </p>
+              </div>
+            </div>
+
+            <div className="flex items-center gap-2">
+              <span className="text-lg">{getMovementPatternIcon(exercise.movement_pattern)}</span>
+              <div>
+                <p className={typography.caption()}>Movement</p>
+                <p className={`${typography.cardSubtitle()} capitalize`}>
+                  {exercise.movement_pattern}
+                </p>
+              </div>
             </div>
           </div>
 
-          <div className="flex items-center gap-2">
-            <Dumbbell className="h-4 w-4 text-primary" />
-            <div>
-              <p className="text-xs text-muted-foreground">Equipment</p>
-              <p className="text-sm font-medium">{formatEquipment(exercise.equipment_type)}</p>
-            </div>
-          </div>
-
-          <div className="flex items-center gap-2">
-            <span className="text-lg">{getMovementPatternIcon(exercise.movement_pattern)}</span>
-            <div>
-              <p className="text-xs text-muted-foreground">Movement</p>
-              <p className="text-sm font-medium capitalize">{exercise.movement_pattern}</p>
-            </div>
-          </div>
-        </div>
-
-        {/* Badges */}
-        <div className="flex flex-wrap gap-2">
-          <Badge className={getDifficultyColor(exercise.difficulty)}>
-            {exercise.difficulty.charAt(0).toUpperCase() + exercise.difficulty.slice(1)}
-          </Badge>
-          <Badge variant="secondary">
-            {exercise.is_compound ? 'Compound' : 'Isolation'}
-          </Badge>
-          {exercise.secondary_muscle_groups && exercise.secondary_muscle_groups.length > 0 && (
-            <Badge variant="outline">
-              +{exercise.secondary_muscle_groups.length} Secondary
+          {/* Badges */}
+          <div className="flex flex-wrap gap-2">
+            <Badge className={`${getDifficultyColor(exercise.difficulty)} ${typography.caption()}`}>
+              {exercise.difficulty.charAt(0).toUpperCase() + exercise.difficulty.slice(1)}
             </Badge>
-          )}
+            <Badge variant="secondary" className={typography.caption()}>
+              {exercise.is_compound ? 'Compound' : 'Isolation'}
+            </Badge>
+            {exercise.secondary_muscle_groups && exercise.secondary_muscle_groups.length > 0 && (
+              <Badge variant="outline" className={typography.caption()}>
+                +
+                <span className={`${typography.metricNumber()} text-xs`}>
+                  {exercise.secondary_muscle_groups.length}
+                </span>{' '}
+                Secondary
+              </Badge>
+            )}
           
           {/* Bodyweight Load Estimation Badge (Feature Flagged) */}
-          {showLoadBadge && effectiveLoad !== null && exercise.type === 'reps' && (
-            <Badge 
-              variant="outline" 
-              className="bg-gradient-to-r from-emerald-500/10 to-teal-500/10 text-emerald-200 border-emerald-500/30 shadow-lg"
-              aria-label={`Estimated load per rep: ${formatLoadKg(effectiveLoad)} kg using ${isDefaultBw ? 'default' : 'profile'} bodyweight`}
-            >
-              <Activity className="w-3 h-3 mr-1" />
-              Est. Load @ {formatLoadKg(bodyweightKg)} kg{isDefaultBw ? ' (default)' : ''}: ≈{formatLoadKg(effectiveLoad)} kg
-            </Badge>
-          )}
+            {showLoadBadge && effectiveLoad !== null && exercise.type === 'reps' && (
+              <Badge
+                variant="outline"
+                className={`bg-gradient-to-r from-emerald-500/10 to-teal-500/10 text-emerald-200 border-emerald-500/30 shadow-lg ${typography.caption()}`}
+                aria-label={`Estimated load per rep: ${formatLoadKg(effectiveLoad)} kg using ${isDefaultBw ? 'default' : 'profile'} bodyweight`}
+              >
+                <Activity className="w-3 h-3 mr-1" />
+                Est. Load @
+                <span className={`${typography.metricNumber()} text-xs ml-1`}>
+                  {formatLoadKg(bodyweightKg)}
+                </span>
+                kg{isDefaultBw ? ' (default)' : ''}: ≈
+                <span className={`${typography.metricNumber()} text-xs ml-1`}>
+                  {formatLoadKg(effectiveLoad)}
+                </span>
+                kg
+              </Badge>
+            )}
           
           {/* Isometric Load Badge */}
-          {showLoadBadge && isometricLoad !== null && ['hold', 'time'].includes(exercise.type) && (
-            <Badge 
-              variant="outline" 
-              className="bg-gradient-to-r from-amber-500/10 to-orange-500/10 text-amber-200 border-amber-500/30 shadow-lg"
-              aria-label={`Isometric load: ${formatLoadKg(isometricLoad)} kg using ${isDefaultBw ? 'default' : 'profile'} bodyweight`}
-            >
-              <Target className="w-3 h-3 mr-1" />
-              Isometric load: {formatLoadKg(isometricLoad)} kg{isDefaultBw ? ' (default)' : ''}
-            </Badge>
-          )}
+            {showLoadBadge && isometricLoad !== null && ['hold', 'time'].includes(exercise.type) && (
+              <Badge
+                variant="outline"
+                className={`bg-gradient-to-r from-amber-500/10 to-orange-500/10 text-amber-200 border-amber-500/30 shadow-lg ${typography.caption()}`}
+                aria-label={`Isometric load: ${formatLoadKg(isometricLoad)} kg using ${isDefaultBw ? 'default' : 'profile'} bodyweight`}
+              >
+                <Target className="w-3 h-3 mr-1" />
+                Isometric load:
+                <span className={`${typography.metricNumber()} text-xs ml-1`}>
+                  {formatLoadKg(isometricLoad)}
+                </span>
+                kg{isDefaultBw ? ' (default)' : ''}
+              </Badge>
+            )}
         </div>
 
         {/* Smart Insights Section */}

--- a/src/components/exercises/FilterChips.tsx
+++ b/src/components/exercises/FilterChips.tsx
@@ -40,16 +40,17 @@ export function FilterChips({ filters, onRemoveFilter, onClearAll }: FilterChips
         'rounded-lg border border-white/15'
       )}
     >
-      <div className="flex items-center justify-between mb-2">
-        <span className="text-sm font-medium text-foreground">
-          Active Filters ({totalActiveFilters})
-        </span>
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={onClearAll}
-          className={cn(
-            componentPatterns.button.ghost(),
+        <div className="flex items-center justify-between mb-2">
+          <div className="flex items-center gap-1">
+            <span className={typography.bodySmall()}>Active Filters</span>
+            <span className={typography.metricNumber()}>{totalActiveFilters}</span>
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onClearAll}
+            className={cn(
+              componentPatterns.button.ghost(),
             typography.caption(),
             'h-6 px-2',
             `transition-all ${designTokens.animations.hover.duration} ${designTokens.animations.hover.easing}`,

--- a/src/components/exercises/FilterPresets.tsx
+++ b/src/components/exercises/FilterPresets.tsx
@@ -118,30 +118,35 @@ export function FilterPresets({ onApplyFilter, activeFilters }: FilterPresetsPro
   };
 
   return (
-    <div className={`mb-[${designTokens.spacing.lg}]`}>
-      <h3 className={`mb-[${designTokens.spacing.sm}] text-sm font-medium text-muted-foreground`}>
-        Quick Filters
-      </h3>
-      <div className={`flex flex-wrap gap-[${designTokens.spacing.sm}]`}>
-        {QUICK_FILTERS.map((preset) => (
-          <Button
-            key={preset.name}
-            variant="ghost"
-            size="sm"
-            onClick={() => handlePresetClick(preset)}
-            className={cn(
-              componentPatterns.button.secondary(),
-              typography.caption(),
-              'flex items-center gap-2 h-8 px-3',
-              `transition-all ${designTokens.animations.hover.duration} ${designTokens.animations.hover.easing}`,
-              `hover:${designTokens.animations.hover.scale} active:${designTokens.animations.press.scale}`,
-              isPresetActive(preset) && `bg-gradient-to-r from-purple-600 to-pink-500 text-white ${effects.glow.purple()}`
-            )}
-          >
-            <span>{preset.icon}</span>
-            {preset.name}
-          </Button>
-        ))}
+      <div className={`mb-[${designTokens.spacing.lg}]`}>
+        <h3
+          className={cn(
+            typography.sectionHeading(),
+            `mb-[${designTokens.spacing.sm}]`
+          )}
+        >
+          Quick Filters
+        </h3>
+        <div className={`flex flex-wrap gap-[${designTokens.spacing.sm}]`}>
+          {QUICK_FILTERS.map((preset) => (
+            <Button
+              key={preset.name}
+              variant="ghost"
+              size="sm"
+              onClick={() => handlePresetClick(preset)}
+              className={cn(
+                componentPatterns.button.secondary(),
+                typography.bodySmall(),
+                'flex items-center gap-2 h-8 px-3',
+                `transition-all ${designTokens.animations.hover.duration} ${designTokens.animations.hover.easing}`,
+                `hover:${designTokens.animations.hover.scale} active:${designTokens.animations.press.scale}`,
+                isPresetActive(preset) && `bg-gradient-to-r from-purple-600 to-pink-500 text-white ${effects.glow.purple()}`
+              )}
+            >
+              <span>{preset.icon}</span>
+              {preset.name}
+            </Button>
+          ))}
       </div>
     </div>
   );

--- a/src/pages/AllExercisesPage.tsx
+++ b/src/pages/AllExercisesPage.tsx
@@ -414,7 +414,13 @@ export default function AllExercisesPage({ onAddExercise, standalone = true, onB
           )}
           
           <div className="flex-1 flex justify-center">
-            <h1 className="text-xl font-semibold text-center">
+            <h1
+              className={cn(
+                typography.pageHeading(),
+                typography.brandGradient(),
+                'text-center'
+              )}
+            >
               {standalone ? "Exercise Library" : "Browse Exercises"}
             </h1>
           </div>
@@ -536,20 +542,22 @@ export default function AllExercisesPage({ onAddExercise, standalone = true, onB
                 {getActiveFilterCount() > 0 && (
                   <Badge
                     variant="secondary"
-                    className={cn(
-                      'ml-2 h-5 px-1.5',
-                      typography.caption()
-                    )}
+                    className={cn('ml-2 h-5 px-1.5', typography.caption())}
                   >
-                    {getActiveFilterCount()}
+                    <span className={cn(typography.metricNumber(), 'text-xs')}>
+                      {getActiveFilterCount()}
+                    </span>
                   </Badge>
                 )}
               </Button>
             </div>
 
             <div className="flex items-center gap-2">
-              <span className="text-sm text-muted-foreground">
-                {filteredExercises.length} exercise{filteredExercises.length !== 1 ? 's' : ''}
+              <span className={typography.metricNumber()}>
+                {filteredExercises.length}
+              </span>
+              <span className={typography.caption()}>
+                exercise{filteredExercises.length !== 1 ? 's' : ''}
               </span>
               <div className="flex border border-white/15 rounded-md">
                 <Button


### PR DESCRIPTION
## Summary
- apply design token typography to exercise library headings and counts
- standardize metadata text and badges in exercise cards
- refine filter chips and presets with body and caption styles

## Testing
- `npm test` *(fails: Cannot find module '@/config/flags')*

------
https://chatgpt.com/codex/tasks/task_e_68aed9bb16c4832684fffbdb46cfd2e6