### PR TITLE
feat: conditionally use unified overview data

### DIFF
--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -35,12 +35,13 @@ const Overview: React.FC = () => {
   // Use unified data service or fallback to existing
   const unifiedData = useUnifiedOverviewData();
   const parallelData = useParallelOverviewData();
-  
-  // Extract data - use existing parallel data for now with feature flag placeholder
+
+  // Determine data source based on feature flag
+  const dataSource = USE_UNIFIED_OVERVIEW_DATA ? unifiedData.data : parallelData;
   const {
-    stats,
-    workouts,
-    processedMetrics,
+    stats = {},
+    workouts = [],
+    processedMetrics = {},
     volumeOverTimeData,
     densityOverTimeData,
     densityStats,
@@ -50,11 +51,11 @@ const Overview: React.FC = () => {
     insights,
     insightsLoading,
     generateWorkoutInsights
-  } = parallelData;
+  } = dataSource || {};
 
-    const generateInsightsCallback = useCallback(() => {
+  const generateInsightsCallback = useCallback(() => {
     if (workouts.length > 0) {
-      generateWorkoutInsights();
+      generateWorkoutInsights?.();
     }
   }, [workouts.length, generateWorkoutInsights]);
 


### PR DESCRIPTION
## Summary
- Switch Overview page to use unified overview data when enabled and fall back otherwise
- Pass stats, processed metrics, and workouts from selected data source to PerformanceSummary and AnalyticsGrid
- Safely trigger workout insights generation only when data and generator are available

## Testing
- `npm run lint` *(fails: Unexpected any, require import issues)*
- `npx eslint src/pages/Overview.tsx` *(fails: Unexpected any types)*
- `npm test` *(fails: Cannot find module '@/config/flags')*
- `NODE_ENV=development npx tsx -e "globalThis.localStorage..."` *(fails: import.meta.env undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68af240a766c8326800949ed9693bca1