### PR TITLE
Conditionally fetch unified overview data behind flag

### DIFF
--- a/src/hooks/useUnifiedOverviewData.ts
+++ b/src/hooks/useUnifiedOverviewData.ts
@@ -5,7 +5,9 @@ import { useDateRange } from '@/context/DateRangeContext';
 import { useWeightUnit } from '@/context/WeightUnitContext';
 import { OverviewDataUnificationService } from '@/services/overview';
 
-export function useUnifiedOverviewData() {
+// Optional `enabled` flag allows consumers to skip fetching when the feature flag
+// is disabled. Defaults to `true` to preserve existing behaviour.
+export function useUnifiedOverviewData(enabled: boolean = true) {
   const { user } = useAuth();
   const { dateRange } = useDateRange();
   const { weightUnit } = useWeightUnit();
@@ -16,7 +18,8 @@ export function useUnifiedOverviewData() {
       if (!user) throw new Error('User not authenticated');
       return OverviewDataUnificationService.getUnifiedOverviewData(dateRange, user.id, weightUnit);
     },
-    enabled: !!user,
+    // Only enable the query if the caller allows it and we have a user
+    enabled: enabled && !!user,
     staleTime: 5 * 60 * 1000, // 5 minutes - same as existing hooks
     gcTime: 10 * 60 * 1000, // 10 minutes cache
     retry: 3,

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -33,7 +33,7 @@ const Overview: React.FC = () => {
                                     localStorage.getItem('enableUnifiedOverview') === 'true';
 
   // Use unified data service or fallback to existing
-  const unifiedData = useUnifiedOverviewData();
+  const unifiedData = useUnifiedOverviewData(USE_UNIFIED_OVERVIEW_DATA);
   const parallelData = useParallelOverviewData();
 
   // Determine data source based on feature flag


### PR DESCRIPTION
## Summary
- Gate unified overview query behind feature flag and allow skipping fetch when disabled
- Call unified overview hook with feature flag in Overview page

## Testing
- `npm run lint` (fails: Unexpected any & require import)
- `npm test` (fails: Cannot find module '@/config/flags')


------
https://chatgpt.com/codex/tasks/task_e_68af25682cb88326a8f79aa10ca17b47