### PR TITLE
feat: scaffold metrics service v2

### DIFF
--- a/src/services/metrics-v2/__fixtures__/barbellOnly.fixture.ts
+++ b/src/services/metrics-v2/__fixtures__/barbellOnly.fixture.ts
@@ -1,0 +1,1 @@
+export default { user: { id: 'u1', bodyweightKg: 80 }, workouts: [], sets: [] };

--- a/src/services/metrics-v2/__fixtures__/bodyweightOnly.fixture.ts
+++ b/src/services/metrics-v2/__fixtures__/bodyweightOnly.fixture.ts
@@ -1,0 +1,1 @@
+export default { user: { id: 'u1', bodyweightKg: 80 }, workouts: [], sets: [] };

--- a/src/services/metrics-v2/__fixtures__/dstBoundary.fixture.ts
+++ b/src/services/metrics-v2/__fixtures__/dstBoundary.fixture.ts
@@ -1,0 +1,1 @@
+export default { user: { id: 'u1', bodyweightKg: 80 }, workouts: [], sets: [] };

--- a/src/services/metrics-v2/__fixtures__/mixedStatic.fixture.ts
+++ b/src/services/metrics-v2/__fixtures__/mixedStatic.fixture.ts
@@ -1,0 +1,1 @@
+export default { user: { id: 'u1', bodyweightKg: 80 }, workouts: [], sets: [] };

--- a/src/services/metrics-v2/__fixtures__/zeroViews.fixture.ts
+++ b/src/services/metrics-v2/__fixtures__/zeroViews.fixture.ts
@@ -1,0 +1,1 @@
+export default { user: { id: 'u1', bodyweightKg: 80 }, workouts: [], sets: [] };

--- a/src/services/metrics-v2/__tests__/ChartAdapter.test.ts
+++ b/src/services/metrics-v2/__tests__/ChartAdapter.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { toChartSeries } from '../chartAdapter';
+
+describe('ChartAdapter', () => {
+  it('aligns labels and datasets', () => {
+    const out = toChartSeries([{ date: '2025-08-01', value: 0 }]);
+    expect(out.labels.length).toBe(out.datasets.length);
+  });
+});

--- a/src/services/metrics-v2/__tests__/ServiceOutput.test.ts
+++ b/src/services/metrics-v2/__tests__/ServiceOutput.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { getMetricsV2, InMemoryRepoStub } from '../index';
+
+describe('ServiceOutput shape (v2)', () => {
+  it('returns a versioned, canonical structure', async () => {
+    const out = await getMetricsV2(InMemoryRepoStub, 'u1', { from: new Date(), to: new Date() });
+    expect(out.meta.version).toBe('v2');
+    expect(out.series.volume.length).toBe(out.series.volume.length); // sanity
+    expect(out).toMatchSnapshot();
+  });
+});

--- a/src/services/metrics-v2/__tests__/__snapshots__/ServiceOutput.test.ts.snap
+++ b/src/services/metrics-v2/__tests__/__snapshots__/ServiceOutput.test.ts.snap
@@ -1,0 +1,30 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ServiceOutput shape (v2) > returns a versioned, canonical structure 1`] = `
+{
+  "meta": {
+    "generatedAt": "2025-08-27T17:40:15.004Z",
+    "inputs": {
+      "tz": "Europe/Warsaw",
+      "units": "kg|min",
+    },
+    "version": "v2",
+  },
+  "perWorkout": [],
+  "prs": [],
+  "series": {
+    "cvr": [],
+    "density": [],
+    "reps": [],
+    "sets": [],
+    "volume": [],
+  },
+  "totals": {
+    "durationMin": 0,
+    "totalReps": 0,
+    "totalSets": 0,
+    "totalVolumeKg": 0,
+    "workouts": 0,
+  },
+}
+`;

--- a/src/services/metrics-v2/aggregators.ts
+++ b/src/services/metrics-v2/aggregators.ts
@@ -1,0 +1,20 @@
+// Aggregation signatures (implement later). Europe/Warsaw day bucketing to be added later.
+import { PerWorkoutMetrics, Totals, TimeSeriesPoint } from './dto';
+
+export function aggregatePerWorkout(/* workouts, sets, calculators */): PerWorkoutMetrics[] {
+  // TODO: implement
+  return [];
+}
+
+export function aggregateTotals(perWorkout: PerWorkoutMetrics[]): Totals {
+  // TODO: implement
+  return { totalVolumeKg: 0, totalSets: 0, totalReps: 0, workouts: 0, durationMin: 0 };
+}
+
+export function rollingWindows(
+  perWorkout: PerWorkoutMetrics[],
+  kind: 'volume'|'sets'|'reps'|'density'|'cvr'
+): TimeSeriesPoint[] {
+  // TODO: implement
+  return [];
+}

--- a/src/services/metrics-v2/calculators.ts
+++ b/src/services/metrics-v2/calculators.ts
@@ -1,0 +1,21 @@
+// Calculator signatures (implement later). Keep factors as data, not code.
+export const loadFactorMap: Record<string, number> = {
+  'Pull-Up': 0.93,
+  'Chin-Up': 0.95,
+  'Dip': 0.84,
+};
+
+export function calcSetVolume(weightKg: number | undefined, reps: number | undefined): number {
+  // TODO: implement
+  return 0;
+}
+
+export function calcBodyweightLoad(userBwKg: number, exerciseName: string): number {
+  // TODO: implement
+  return 0;
+}
+
+export function calcIsometricLoad(weightKg: number | undefined, seconds: number | undefined): number {
+  // TODO: implement
+  return 0;
+}

--- a/src/services/metrics-v2/chartAdapter.ts
+++ b/src/services/metrics-v2/chartAdapter.ts
@@ -1,0 +1,11 @@
+// Adapter from domain series -> chart component shape
+import { TimeSeriesPoint } from './dto';
+
+export function toChartSeries(
+  series: TimeSeriesPoint[],
+  keys: { xKey: 'date'; yKey: 'value' } = { xKey: 'date', yKey: 'value' }
+) {
+  const labels: string[] = series.map(p => p.date);
+  const datasets: number[] = series.map(p => p.value);
+  return { labels, datasets };
+}

--- a/src/services/metrics-v2/dto.ts
+++ b/src/services/metrics-v2/dto.ts
@@ -1,0 +1,49 @@
+// Canonical, versioned DTOs for Metrics Service v2 (units: kg, min; dates: ISO YYYY-MM-DD)
+export type TimeSeriesPoint = { date: string; value: number };
+
+export type PerWorkoutMetrics = {
+  workoutId: string;
+  startedAt: string;           // ISO timestamp
+  totalVolumeKg: number;
+  totalSets: number;
+  totalReps: number;
+  durationMin: number;
+  activeMin: number;
+  restMin: number;
+};
+
+export type Totals = {
+  totalVolumeKg: number;
+  totalSets: number;
+  totalReps: number;
+  workouts: number;
+  durationMin: number;
+};
+
+export type PersonalRecord = {
+  id: string;
+  exerciseName: string;
+  type: '1RM' | '5RM' | 'VolumeSession' | 'BestSet';
+  value: number;
+  unit: 'kg' | 'reps' | 'kg·s';
+  date: string; // ISO day (YYYY-MM-DD)
+};
+
+export type ServiceOutput = {
+  totals: Totals;
+  perWorkout: PerWorkoutMetrics[];
+  prs: PersonalRecord[];
+  series: {
+    volume: TimeSeriesPoint[];
+    sets: TimeSeriesPoint[];
+    reps: TimeSeriesPoint[];
+    density: TimeSeriesPoint[];
+    cvr: TimeSeriesPoint[]; // rule later: if views=0 => 0
+  };
+  meta: {
+    generatedAt: string;
+    version: 'v2';
+    inputs: { tz: 'Europe/Warsaw'; units: 'kg|min' };
+    BW_ASSUMED?: boolean;
+  };
+};

--- a/src/services/metrics-v2/flags.ts
+++ b/src/services/metrics-v2/flags.ts
@@ -1,0 +1,4 @@
+// Feature flags (env or runtime toggles will be added later)
+export const METRICS_SERVICE_V2 = false;
+export const METRICS_SERVICE_V2_SHADOW = false;
+export const METRICS_SERVICE_V2_COMPONENT_VOLUME = false;

--- a/src/services/metrics-v2/index.ts
+++ b/src/services/metrics-v2/index.ts
@@ -1,0 +1,33 @@
+// Public surface for v2 + DI-friendly façade
+import type { ServiceOutput } from './dto';
+import type { MetricsRepository, DateRange } from './repository';
+
+export type MetricsConfig = {
+  tz?: 'Europe/Warsaw';
+  units?: 'kg|min';
+};
+
+export async function getMetricsV2(
+  repo: MetricsRepository,
+  userId: string,
+  range: DateRange,
+  config: MetricsConfig = { tz: 'Europe/Warsaw', units: 'kg|min' }
+): Promise<ServiceOutput> {
+  // TODO: Call repo, calculators, aggregators, prDetector when implemented
+  return {
+    totals: { totalVolumeKg: 0, totalSets: 0, totalReps: 0, workouts: 0, durationMin: 0 },
+    perWorkout: [],
+    prs: [],
+    series: { volume: [], sets: [], reps: [], density: [], cvr: [] },
+    meta: {
+      generatedAt: new Date().toISOString(),
+      version: 'v2',
+      inputs: { tz: 'Europe/Warsaw', units: 'kg|min' },
+    },
+  };
+}
+
+export * from './dto';
+export * from './repository';
+export * from './flags';
+export * from './chartAdapter';

--- a/src/services/metrics-v2/prDetector.ts
+++ b/src/services/metrics-v2/prDetector.ts
@@ -1,0 +1,7 @@
+// PR detection signatures (implement later): 1RM/5RM/Best session tonnage, tie-breakers.
+import { PersonalRecord } from './dto';
+
+export function findPRs(/* history inputs */): PersonalRecord[] {
+  // TODO: implement
+  return [];
+}

--- a/src/services/metrics-v2/repository.ts
+++ b/src/services/metrics-v2/repository.ts
@@ -1,0 +1,19 @@
+// Repository interface (DI). Implementations will use Supabase/BigQuery later.
+export type DateRange = { from: Date; to: Date };
+
+export interface MetricsRepository {
+  getWorkouts(range: DateRange, userId: string): Promise<{ id: string; startedAt: string }[]>;
+  getSets(workoutIds: string[]): Promise<{
+    workoutId: string;
+    exerciseName: string;
+    weightKg?: number;
+    reps?: number;
+    seconds?: number;
+    isBodyweight?: boolean;
+  }[]>;
+}
+
+export const InMemoryRepoStub: MetricsRepository = {
+  async getWorkouts() { return []; },
+  async getSets() { return []; },
+};


### PR DESCRIPTION
## Summary
- scaffold metrics service v2 with versioned DTOs and DI-friendly facade
- add repository interface, calculators/aggregators/PR detector stubs
- introduce chart adapter, feature flags, fixtures, and tests

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npx vitest run src/services/metrics-v2/__tests__/ServiceOutput.test.ts src/services/metrics-v2/__tests__/ChartAdapter.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68af3ccfa5288326a21fc48a10c8ba66