### PR TITLE
feat: add metrics shadow facade with parity telemetry

### DIFF
--- a/src/services/metrics-v2/__fixtures__/barbellOnly.fixture.ts
+++ b/src/services/metrics-v2/__fixtures__/barbellOnly.fixture.ts
@@ -1,0 +1,1 @@
+export default { user: { id: 'u1', bodyweightKg: 80 }, workouts: [], sets: [] };

--- a/src/services/metrics-v2/__fixtures__/bodyweightOnly.fixture.ts
+++ b/src/services/metrics-v2/__fixtures__/bodyweightOnly.fixture.ts
@@ -1,0 +1,1 @@
+export default { user: { id: 'u1', bodyweightKg: 80 }, workouts: [], sets: [] };

--- a/src/services/metrics-v2/__fixtures__/dstBoundary.fixture.ts
+++ b/src/services/metrics-v2/__fixtures__/dstBoundary.fixture.ts
@@ -1,0 +1,1 @@
+export default { user: { id: 'u1', bodyweightKg: 80 }, workouts: [], sets: [] };

--- a/src/services/metrics-v2/__fixtures__/mixedStatic.fixture.ts
+++ b/src/services/metrics-v2/__fixtures__/mixedStatic.fixture.ts
@@ -1,0 +1,1 @@
+export default { user: { id: 'u1', bodyweightKg: 80 }, workouts: [], sets: [] };

--- a/src/services/metrics-v2/__fixtures__/zeroViews.fixture.ts
+++ b/src/services/metrics-v2/__fixtures__/zeroViews.fixture.ts
@@ -1,0 +1,1 @@
+export default { user: { id: 'u1', bodyweightKg: 80 }, workouts: [], sets: [] };

--- a/src/services/metrics-v2/__tests__/ChartAdapter.test.ts
+++ b/src/services/metrics-v2/__tests__/ChartAdapter.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { toChartSeries } from '../chartAdapter';
+
+describe('ChartAdapter', () => {
+  it('aligns labels and datasets', () => {
+    const out = toChartSeries([{ date: '2025-08-01', value: 0 }]);
+    expect(out.labels.length).toBe(out.datasets.length);
+  });
+});

--- a/src/services/metrics-v2/__tests__/ServiceOutput.test.ts
+++ b/src/services/metrics-v2/__tests__/ServiceOutput.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { getMetricsV2, InMemoryRepoStub } from '../index';
+
+describe('ServiceOutput shape (v2)', () => {
+  it('returns a versioned, canonical structure', async () => {
+    const out = await getMetricsV2(InMemoryRepoStub, 'u1', { from: new Date(), to: new Date() });
+    expect(out.meta.version).toBe('v2');
+    expect(out.series.volume.length).toBe(out.series.volume.length); // sanity
+    expect(out).toMatchSnapshot();
+  });
+});

--- a/src/services/metrics-v2/__tests__/__snapshots__/ServiceOutput.test.ts.snap
+++ b/src/services/metrics-v2/__tests__/__snapshots__/ServiceOutput.test.ts.snap
@@ -1,0 +1,30 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ServiceOutput shape (v2) > returns a versioned, canonical structure 1`] = `
+{
+  "meta": {
+    "generatedAt": "2025-08-27T17:40:15.004Z",
+    "inputs": {
+      "tz": "Europe/Warsaw",
+      "units": "kg|min",
+    },
+    "version": "v2",
+  },
+  "perWorkout": [],
+  "prs": [],
+  "series": {
+    "cvr": [],
+    "density": [],
+    "reps": [],
+    "sets": [],
+    "volume": [],
+  },
+  "totals": {
+    "durationMin": 0,
+    "totalReps": 0,
+    "totalSets": 0,
+    "totalVolumeKg": 0,
+    "workouts": 0,
+  },
+}
+`;

--- a/src/services/metrics-v2/aggregators.ts
+++ b/src/services/metrics-v2/aggregators.ts
@@ -1,0 +1,20 @@
+// Aggregation signatures (implement later). Europe/Warsaw day bucketing to be added later.
+import { PerWorkoutMetrics, Totals, TimeSeriesPoint } from './dto';
+
+export function aggregatePerWorkout(/* workouts, sets, calculators */): PerWorkoutMetrics[] {
+  // TODO: implement
+  return [];
+}
+
+export function aggregateTotals(perWorkout: PerWorkoutMetrics[]): Totals {
+  // TODO: implement
+  return { totalVolumeKg: 0, totalSets: 0, totalReps: 0, workouts: 0, durationMin: 0 };
+}
+
+export function rollingWindows(
+  perWorkout: PerWorkoutMetrics[],
+  kind: 'volume'|'sets'|'reps'|'density'|'cvr'
+): TimeSeriesPoint[] {
+  // TODO: implement
+  return [];
+}

--- a/src/services/metrics-v2/calculators.ts
+++ b/src/services/metrics-v2/calculators.ts
@@ -1,0 +1,21 @@
+// Calculator signatures (implement later). Keep factors as data, not code.
+export const loadFactorMap: Record<string, number> = {
+  'Pull-Up': 0.93,
+  'Chin-Up': 0.95,
+  'Dip': 0.84,
+};
+
+export function calcSetVolume(weightKg: number | undefined, reps: number | undefined): number {
+  // TODO: implement
+  return 0;
+}
+
+export function calcBodyweightLoad(userBwKg: number, exerciseName: string): number {
+  // TODO: implement
+  return 0;
+}
+
+export function calcIsometricLoad(weightKg: number | undefined, seconds: number | undefined): number {
+  // TODO: implement
+  return 0;
+}

--- a/src/services/metrics-v2/chartAdapter.ts
+++ b/src/services/metrics-v2/chartAdapter.ts
@@ -1,0 +1,11 @@
+// Adapter from domain series -> chart component shape
+import { TimeSeriesPoint } from './dto';
+
+export function toChartSeries(
+  series: TimeSeriesPoint[],
+  keys: { xKey: 'date'; yKey: 'value' } = { xKey: 'date', yKey: 'value' }
+) {
+  const labels: string[] = series.map(p => p.date);
+  const datasets: number[] = series.map(p => p.value);
+  return { labels, datasets };
+}

--- a/src/services/metrics-v2/dto.ts
+++ b/src/services/metrics-v2/dto.ts
@@ -1,0 +1,49 @@
+// Canonical, versioned DTOs for Metrics Service v2 (units: kg, min; dates: ISO YYYY-MM-DD)
+export type TimeSeriesPoint = { date: string; value: number };
+
+export type PerWorkoutMetrics = {
+  workoutId: string;
+  startedAt: string;           // ISO timestamp
+  totalVolumeKg: number;
+  totalSets: number;
+  totalReps: number;
+  durationMin: number;
+  activeMin: number;
+  restMin: number;
+};
+
+export type Totals = {
+  totalVolumeKg: number;
+  totalSets: number;
+  totalReps: number;
+  workouts: number;
+  durationMin: number;
+};
+
+export type PersonalRecord = {
+  id: string;
+  exerciseName: string;
+  type: '1RM' | '5RM' | 'VolumeSession' | 'BestSet';
+  value: number;
+  unit: 'kg' | 'reps' | 'kg·s';
+  date: string; // ISO day (YYYY-MM-DD)
+};
+
+export type ServiceOutput = {
+  totals: Totals;
+  perWorkout: PerWorkoutMetrics[];
+  prs: PersonalRecord[];
+  series: {
+    volume: TimeSeriesPoint[];
+    sets: TimeSeriesPoint[];
+    reps: TimeSeriesPoint[];
+    density: TimeSeriesPoint[];
+    cvr: TimeSeriesPoint[]; // rule later: if views=0 => 0
+  };
+  meta: {
+    generatedAt: string;
+    version: 'v2';
+    inputs: { tz: 'Europe/Warsaw'; units: 'kg|min' };
+    BW_ASSUMED?: boolean;
+  };
+};

--- a/src/services/metrics-v2/flags.ts
+++ b/src/services/metrics-v2/flags.ts
@@ -1,0 +1,4 @@
+// Feature flags (env or runtime toggles will be added later)
+export const METRICS_SERVICE_V2 = false;
+export const METRICS_SERVICE_V2_SHADOW = false;
+export const METRICS_SERVICE_V2_COMPONENT_VOLUME = false;

--- a/src/services/metrics-v2/index.ts
+++ b/src/services/metrics-v2/index.ts
@@ -1,0 +1,33 @@
+// Public surface for v2 + DI-friendly façade
+import type { ServiceOutput } from './dto';
+import type { MetricsRepository, DateRange } from './repository';
+
+export type MetricsConfig = {
+  tz?: 'Europe/Warsaw';
+  units?: 'kg|min';
+};
+
+export async function getMetricsV2(
+  repo: MetricsRepository,
+  userId: string,
+  range: DateRange,
+  config: MetricsConfig = { tz: 'Europe/Warsaw', units: 'kg|min' }
+): Promise<ServiceOutput> {
+  // TODO: Call repo, calculators, aggregators, prDetector when implemented
+  return {
+    totals: { totalVolumeKg: 0, totalSets: 0, totalReps: 0, workouts: 0, durationMin: 0 },
+    perWorkout: [],
+    prs: [],
+    series: { volume: [], sets: [], reps: [], density: [], cvr: [] },
+    meta: {
+      generatedAt: new Date().toISOString(),
+      version: 'v2',
+      inputs: { tz: 'Europe/Warsaw', units: 'kg|min' },
+    },
+  };
+}
+
+export * from './dto';
+export * from './repository';
+export * from './flags';
+export * from './chartAdapter';

--- a/src/services/metrics-v2/prDetector.ts
+++ b/src/services/metrics-v2/prDetector.ts
@@ -1,0 +1,7 @@
+// PR detection signatures (implement later): 1RM/5RM/Best session tonnage, tie-breakers.
+import { PersonalRecord } from './dto';
+
+export function findPRs(/* history inputs */): PersonalRecord[] {
+  // TODO: implement
+  return [];
+}

--- a/src/services/metrics-v2/repository.ts
+++ b/src/services/metrics-v2/repository.ts
@@ -1,0 +1,19 @@
+// Repository interface (DI). Implementations will use Supabase/BigQuery later.
+export type DateRange = { from: Date; to: Date };
+
+export interface MetricsRepository {
+  getWorkouts(range: DateRange, userId: string): Promise<{ id: string; startedAt: string }[]>;
+  getSets(workoutIds: string[]): Promise<{
+    workoutId: string;
+    exerciseName: string;
+    weightKg?: number;
+    reps?: number;
+    seconds?: number;
+    isBodyweight?: boolean;
+  }[]>;
+}
+
+export const InMemoryRepoStub: MetricsRepository = {
+  async getWorkouts() { return []; },
+  async getSets() { return []; },
+};

--- a/src/services/metrics/__tests__/facade.test.ts
+++ b/src/services/metrics/__tests__/facade.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { getMetricsShadow } from '../getMetricsFacade';
+import { InMemoryRepoStub } from '../../metrics-v2';
+import * as Telemetry from '../telemetry';
+
+const mkV1 = (over: any = {}) => ({
+  totals: { totalVolumeKg: 10, ...over.totals },
+  prs: Array.isArray(over.prs) ? over.prs : [1],
+  series: { volume: [1,2,3], ...over.series },
+});
+
+describe('getMetricsShadow', () => {
+  const fetchV1 = async () => mkV1();
+  const range = { from: new Date('2025-08-01'), to: new Date('2025-08-31') };
+
+  it('returns v1 by default (no flags)', async () => {
+    const out = await getMetricsShadow('u1', range, { fetchV1, repoV2: InMemoryRepoStub });
+    // We can only assert shape hints, since v1 is unknown typed
+    expect((out as any).totals.totalVolumeKg).toBe(10);
+  });
+
+  it('shadow: calls v2 and emits telemetry on mismatch, but returns v1', async () => {
+    const spy = vi.spyOn(Telemetry, 'emitMetricsTelemetry').mockImplementation(() => {});
+    const out = await getMetricsShadow('u1', range, {
+      fetchV1: async () => mkV1({ totals: { totalVolumeKg: 123 } }),
+      repoV2: InMemoryRepoStub,
+      flags: { shadow: true },
+      userIdHashFn: () => 'user_hash',
+    });
+    expect((out as any).totals.totalVolumeKg).toBe(123);
+    expect(spy).toHaveBeenCalled(); // mismatch vs empty v2 stub
+    spy.mockRestore();
+  });
+
+  it('v2: returns ServiceOutput when v2 flag is on', async () => {
+    const out = await getMetricsShadow('u1', range, {
+      fetchV1,
+      repoV2: InMemoryRepoStub,
+      flags: { v2: true },
+    });
+    // v2 stub returns canonical ServiceOutput with zeroed fields
+    expect((out as any).meta?.version).toBe('v2');
+  });
+});
+

--- a/src/services/metrics/__tests__/parity.test.ts
+++ b/src/services/metrics/__tests__/parity.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { summarizeParityDiff } from '../parity';
+
+describe('summarizeParityDiff', () => {
+  it('returns null when key fields match', () => {
+    const v1 = { totals: { totalVolumeKg: 100 }, prs: [1,2], series: { volume: [1,2,3] } };
+    const v2 = { totals: { totalVolumeKg: 100 }, prs: [1,2], series: { volume: [1,2,3] } };
+    expect(summarizeParityDiff(v1, v2)).toBeNull();
+  });
+
+  it('reports mismatches when key fields differ', () => {
+    const v1 = { totals: { totalVolumeKg: 100 }, prs: [1], series: { volume: [1,2,3] } };
+    const v2 = { totals: { totalVolumeKg: 120 }, prs: [], series: { volume: [1,2] } };
+    const diff = summarizeParityDiff(v1, v2)!;
+    expect(diff.mismatches).toContain('totals.totalVolumeKg');
+    expect(diff.mismatches).toContain('prs.length');
+    expect(diff.mismatches).toContain('series.volume.len');
+  });
+});
+

--- a/src/services/metrics/getMetricsFacade.ts
+++ b/src/services/metrics/getMetricsFacade.ts
@@ -1,0 +1,59 @@
+import type { DateRange, MetricsRepository } from '../metrics-v2/repository';
+import { getMetricsV2, type ServiceOutput } from '../metrics-v2';
+import { summarizeParityDiff } from './parity';
+import { emitMetricsTelemetry, type ParityEvent } from './telemetry';
+
+export type FetchV1<TV1> = (userId: string, range: DateRange) => Promise<TV1>;
+
+export type ShadowFlags = {
+  v2?: boolean;     // full cutover (returns v2)
+  shadow?: boolean; // run v2 in parallel, compare, emit telemetry, but return v1
+};
+
+export type GetMetricsShadowOptions<TV1> = {
+  fetchV1: FetchV1<TV1>;
+  repoV2: MetricsRepository;
+  flags?: ShadowFlags;
+  userIdHashFn?: (userId: string) => string; // optional, to avoid PII
+};
+
+export async function getMetricsShadow<TV1>(
+  userId: string,
+  range: DateRange,
+  opts: GetMetricsShadowOptions<TV1>
+): Promise<TV1 | ServiceOutput> {
+  const { fetchV1, repoV2, flags = {}, userIdHashFn } = opts;
+
+  // Cutover path: return v2
+  if (flags.v2) {
+    return getMetricsV2(repoV2, userId, range);
+  }
+
+  // Default path: return v1
+  const v1 = await fetchV1(userId, range);
+
+  // Shadow path: run v2 in parallel, compare, emit telemetry (non-throwing)
+  if (flags.shadow) {
+    try {
+      const v2 = await getMetricsV2(repoV2, userId, range);
+      const diff = summarizeParityDiff(v1, v2);
+      if (diff) {
+        const event: ParityEvent = {
+          kind: 'metrics_parity_mismatch',
+          userIdHash: userIdHashFn ? userIdHashFn(userId) : undefined,
+          diff,
+        };
+        emitMetricsTelemetry(event);
+      }
+    } catch (e) {
+      emitMetricsTelemetry({
+        kind: 'metrics_parity_error',
+        userIdHash: userIdHashFn ? userIdHashFn(userId) : undefined,
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
+
+  return v1;
+}
+

--- a/src/services/metrics/parity.ts
+++ b/src/services/metrics/parity.ts
@@ -1,0 +1,48 @@
+import type { ServiceOutput } from '../metrics-v2';
+
+export type ParityDiff = {
+  mismatches: string[]; // e.g., ['totals.totalVolumeKg', 'prs.length', 'series.volume.len']
+  totals?: { v1?: number; v2?: number };
+  prsLength?: { v1: number; v2: number };
+  seriesVolumeLen?: { v1: number; v2: number };
+};
+
+// Non-throwing summary comparator: returns null if "good enough" equal
+export function summarizeParityDiff(v1: unknown, v2: unknown): ParityDiff | null {
+  // We only compare a few load-bearing fields to avoid overfitting to v1 internals
+  const mismatches: string[] = [];
+
+  // Total volume (if present)
+  const v1Total = (v1 as any)?.totals?.totalVolumeKg;
+  const v2Total = (v2 as ServiceOutput | undefined)?.totals?.totalVolumeKg;
+  if (isFiniteNumber(v1Total) && isFiniteNumber(v2Total) && v1Total !== v2Total) {
+    mismatches.push('totals.totalVolumeKg');
+  }
+
+  // PRs length
+  const v1PrLen = Array.isArray((v1 as any)?.prs) ? (v1 as any).prs.length : undefined;
+  const v2PrLen = Array.isArray((v2 as any)?.prs) ? (v2 as any).prs.length : undefined;
+  if (isFiniteNumber(v1PrLen) && isFiniteNumber(v2PrLen) && v1PrLen !== v2PrLen) {
+    mismatches.push('prs.length');
+  }
+
+  // Volume series length
+  const v1VolLen = Array.isArray((v1 as any)?.series?.volume) ? (v1 as any).series.volume.length : undefined;
+  const v2VolLen = Array.isArray((v2 as any)?.series?.volume) ? (v2 as any).series.volume.length : undefined;
+  if (isFiniteNumber(v1VolLen) && isFiniteNumber(v2VolLen) && v1VolLen !== v2VolLen) {
+    mismatches.push('series.volume.len');
+  }
+
+  if (mismatches.length === 0) return null;
+
+  const diff: ParityDiff = { mismatches };
+  if (isFiniteNumber(v1Total) || isFiniteNumber(v2Total)) diff.totals = { v1: v1Total, v2: v2Total };
+  if (isFiniteNumber(v1PrLen) && isFiniteNumber(v2PrLen)) diff.prsLength = { v1: v1PrLen, v2: v2PrLen };
+  if (isFiniteNumber(v1VolLen) && isFiniteNumber(v2VolLen)) diff.seriesVolumeLen = { v1: v1VolLen, v2: v2VolLen };
+  return diff;
+}
+
+function isFiniteNumber(n: unknown): n is number {
+  return typeof n === 'number' && Number.isFinite(n);
+}
+

--- a/src/services/metrics/telemetry.ts
+++ b/src/services/metrics/telemetry.ts
@@ -1,0 +1,11 @@
+import type { ParityDiff } from './parity';
+
+export type ParityEvent =
+  | { kind: 'metrics_parity_mismatch'; userIdHash?: string; diff: ParityDiff }
+  | { kind: 'metrics_parity_error'; userIdHash?: string; error: string };
+
+// No-op emitter for now. Replace with your logger/analytics later.
+export function emitMetricsTelemetry(event: ParityEvent): void {
+  // Intentionally empty; tests can spy on this via jest/vitest mocks.
+}
+


### PR DESCRIPTION
## Summary
- add Metrics Service shadow facade to safely compare v1 and v2
- implement parity diff comparator and telemetry stub
- cover shadow and v2 paths with unit tests

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npx vitest run src/services/metrics/__tests__/parity.test.ts src/services/metrics/__tests__/facade.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68af3ccfa5288326a21fc48a10c8ba66