### PR TITLE
feat(metrics): support exercise filter

### DIFF
--- a/src/services/metrics-v2/service.ts
+++ b/src/services/metrics-v2/service.ts
@@ -76,7 +76,7 @@ export const metricsServiceV2 = {
           const sets = await repository.getSets(workoutIds, userId)
           return sets.map(s => ({
             workoutId: s.workoutId,
-            exerciseName: s.exerciseId || '',
+            exerciseName: s.exerciseName || s.exerciseId || '',
             weightKg: s.weightKg,
             reps: s.reps,
             seconds: undefined,

--- a/src/services/metrics-v2/types.ts
+++ b/src/services/metrics-v2/types.ts
@@ -17,11 +17,12 @@ export interface SetRaw {
   weightKg: number;
   reps: number;
   exerciseId: string;
+  exerciseName?: string;
 }
 
 export interface MetricsRepository {
   getWorkouts(range: DateRange, userId: string): Promise<WorkoutRaw[]>;
-  getSets(workoutIds: string[], userId: string): Promise<SetRaw[]>;
+  getSets(workoutIds: string[], userId: string, exerciseId?: string): Promise<SetRaw[]>;
 }
 
 // In-memory implementation for development/testing
@@ -30,7 +31,7 @@ export class InMemoryMetricsRepository implements MetricsRepository {
     return []
   }
 
-  async getSets(): Promise<SetRaw[]> {
+  async getSets(_workoutIds: string[] = [], _userId: string = '', _exerciseId?: string): Promise<SetRaw[]> {
     return []
   }
 }


### PR DESCRIPTION
## Summary
- include `exercise_id` and optional `exercises` join in Supabase sets query
- allow filtering sets by exercise and return IDs/names
- map exercise details through metrics service

## Testing
- `npm test` *(fails: Unable to find an element with the text: /Est\. Load @ 80 kg:/*)
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68b16f77f8d88326962b6ccd09b06611