### PR TITLE
Add exercise filtering to analytics view

### DIFF
--- a/src/components/analytics/AnalyticsFilterBar.tsx
+++ b/src/components/analytics/AnalyticsFilterBar.tsx
@@ -3,14 +3,24 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Button } from '@/components/ui/button';
 
 type GroupBy = 'day' | 'week' | 'month';
+interface ExerciseOption {
+  id: string;
+  name: string;
+}
 
 export function AnalyticsFilterBar({
   groupBy,
+  exerciseId,
+  exerciseOptions = [],
   onGroupByChange,
+  onExerciseChange,
   onReset,
 }: {
   groupBy: GroupBy;
+  exerciseId?: string;
+  exerciseOptions?: ExerciseOption[];
   onGroupByChange: (g: GroupBy) => void;
+  onExerciseChange?: (id?: string) => void;
   onReset?: () => void;
 }) {
   return (
@@ -26,6 +36,28 @@ export function AnalyticsFilterBar({
           <SelectItem value="month">By month</SelectItem>
         </SelectContent>
       </Select>
+
+      {onExerciseChange && (
+        <>
+          <div className="text-sm text-gray-400">Exercise:</div>
+          <Select
+            value={exerciseId ?? 'all'}
+            onValueChange={(v) => onExerciseChange(v === 'all' ? undefined : v)}
+          >
+            <SelectTrigger className="w-[180px] bg-gray-800/50 border-gray-700 text-gray-200">
+              <SelectValue placeholder="All exercises" />
+            </SelectTrigger>
+            <SelectContent className="bg-gray-900 text-gray-200 border-gray-700">
+              <SelectItem value="all">All exercises</SelectItem>
+              {exerciseOptions.map((opt) => (
+                <SelectItem key={opt.id} value={opt.id}>
+                  {opt.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </>
+      )}
 
       {onReset && (
         <Button variant="outline" className="border-white/10 text-gray-300 hover:bg-white/10" onClick={onReset}>

--- a/src/hooks/useExerciseOptions.ts
+++ b/src/hooks/useExerciseOptions.ts
@@ -1,0 +1,38 @@
+import { useQuery } from '@tanstack/react-query'
+import { supabase } from '@/integrations/supabase/client'
+import { useAuth } from '@/context/AuthContext'
+
+export interface ExerciseOption {
+  id: string
+  name: string
+}
+
+export function useExerciseOptions() {
+  const { user } = useAuth()
+
+  return useQuery<ExerciseOption[]>({
+    queryKey: ['exercise-options', user?.id],
+    enabled: !!user?.id,
+    queryFn: async () => {
+      if (!user?.id) return []
+      const { data, error } = await supabase
+        .from('exercise_sets')
+        .select('exercise_id, exercises(name), workout_sessions!inner(user_id)')
+        .eq('workout_sessions.user_id', user.id)
+
+      if (error) throw error
+
+      const map = new Map<string, string>()
+      for (const row of data || []) {
+        if (row.exercise_id) {
+          const name = (row as any).exercises?.name || row.exercise_id
+          map.set(row.exercise_id, name)
+        }
+      }
+      return Array.from(map.entries())
+        .map(([id, name]) => ({ id, name }))
+        .sort((a, b) => a.name.localeCompare(b.name))
+    },
+  })
+}
+


### PR DESCRIPTION
## Summary
- fetch distinct exercise options from Supabase
- extend analytics filter bar with exercise selector
- include exerciseId in analytics query key and service call

## Testing
- `npm test` *(fails: multiple existing test and snapshot failures)*
- `npm run lint` *(fails: numerous lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68b1721d3a188326b5a4dc7cdbb8cea0