### PR TITLE
feat: populate analytics exercise dropdown

### DIFF
--- a/src/components/analytics/AnalyticsFilterBar.tsx
+++ b/src/components/analytics/AnalyticsFilterBar.tsx
@@ -12,6 +12,7 @@ export function AnalyticsFilterBar({
   groupBy,
   exerciseId,
   exerciseOptions = [],
+  isExerciseLoading = false,
   onGroupByChange,
   onExerciseChange,
   onReset,
@@ -19,6 +20,7 @@ export function AnalyticsFilterBar({
   groupBy: GroupBy;
   exerciseId?: string;
   exerciseOptions?: ExerciseOption[];
+  isExerciseLoading?: boolean;
   onGroupByChange: (g: GroupBy) => void;
   onExerciseChange?: (id?: string) => void;
   onReset?: () => void;
@@ -42,13 +44,24 @@ export function AnalyticsFilterBar({
           <div className="text-sm text-gray-400">Exercise:</div>
           <Select
             value={exerciseId ?? 'all'}
+            disabled={isExerciseLoading}
             onValueChange={(v) => onExerciseChange(v === 'all' ? undefined : v)}
           >
             <SelectTrigger className="w-[180px] bg-gray-800/50 border-gray-700 text-gray-200">
-              <SelectValue placeholder="All exercises" />
+              <SelectValue placeholder={isExerciseLoading ? 'Loading...' : 'All exercises'} />
             </SelectTrigger>
             <SelectContent className="bg-gray-900 text-gray-200 border-gray-700">
               <SelectItem value="all">All exercises</SelectItem>
+              {isExerciseLoading && (
+                <SelectItem value="loading" disabled>
+                  Loading...
+                </SelectItem>
+              )}
+              {!isExerciseLoading && exerciseOptions.length === 0 && (
+                <SelectItem value="none" disabled>
+                  No exercises found
+                </SelectItem>
+              )}
               {exerciseOptions.map((opt) => (
                 <SelectItem key={opt.id} value={opt.id}>
                   {opt.name}

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -28,7 +28,10 @@ const Analytics: React.FC = () => {
   React.useEffect(() => {
     setExerciseId(exerciseParam || undefined);
   }, [exerciseParam]);
-  const { data: exerciseOptions = [] } = useExerciseOptions();
+  const {
+    data: exerciseOptions = [],
+    isLoading: isExerciseOptionsLoading,
+  } = useExerciseOptions();
   const selectedKpi = (kpiParam as 'tonnage' | 'sets' | 'reps' | 'duration' | 'workouts') || 'tonnage';
   const { data, isLoading, isError, error, refetch } = useQuery({
     queryKey: ['metrics-v2', user?.id, dateRange.from?.toISOString(), dateRange.to?.toISOString(), exerciseId],
@@ -231,6 +234,7 @@ const Analytics: React.FC = () => {
               groupBy={groupParam}
               exerciseId={exerciseId}
               exerciseOptions={exerciseOptions}
+              isExerciseLoading={isExerciseOptionsLoading}
               onGroupByChange={onGroupChange}
               onExerciseChange={onExerciseChange}
             />

--- a/src/services/exerciseOptionsService.ts
+++ b/src/services/exerciseOptionsService.ts
@@ -9,7 +9,8 @@ export async function getExerciseOptions(userId: string): Promise<ExerciseOption
   const { data, error } = await supabase
     .from('exercise_sets')
     .select('exercise_id, exercises(name), workout_sessions!inner(user_id)')
-    .eq('workout_sessions.user_id', userId);
+    .eq('workout_sessions.user_id', userId)
+    .not('exercise_id', 'is', null);
 
   if (error) throw error;
 


### PR DESCRIPTION
## Summary
- fetch distinct exercises performed by the user
- load exercise options into analytics filter with loading/empty states
- pass exercise options into analytics page

## Testing
- `npm test` *(fails: ServiceOutput snapshot mismatched)*

------
https://chatgpt.com/codex/tasks/task_e_68b1621919588326a16e1fda8a0aded5