### PR TITLE
Add foreign key for exercise_sets exercise_id

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -551,6 +551,13 @@ export type Database = {
             referencedRelation: "workout_sessions"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "exercise_sets_exercise_id_fkey"
+            columns: ["exercise_id"]
+            isOneToOne: false
+            referencedRelation: "exercises"
+            referencedColumns: ["id"]
+          },
         ]
       }
       set_duration_patterns: {

--- a/supabase/migrations/20250829100512-681a17ff-85ae-4378-a9e9-9e947a900efd.sql
+++ b/supabase/migrations/20250829100512-681a17ff-85ae-4378-a9e9-9e947a900efd.sql
@@ -1,0 +1,12 @@
+-- Add missing foreign key for exercise_sets.exercise_id
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'exercise_sets_exercise_id_fkey'
+  ) THEN
+    ALTER TABLE public.exercise_sets
+    ADD CONSTRAINT exercise_sets_exercise_id_fkey FOREIGN KEY (exercise_id) REFERENCES public.exercises(id);
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- add migration ensuring exercise_sets.exercise_id references exercises
- include exercise-exercises relationship in generated Supabase types

## Testing
- `npm test` *(fails: Unable to find an element with the text...; Snapshot mismatch)*
- `npm run lint` *(fails: Unexpected any)*
- `npx supabase gen types typescript --project-id oglcdlzomfuoyeqeobal --schema public` *(fails: Access token not provided)*

------
https://chatgpt.com/codex/tasks/task_e_68b17b25d3148326a3f350fb1de73026