### PR TITLE
Enable RLS for exercise tables

### DIFF
--- a/supabase/migrations/20250829100600_enable_rls_exercise_tables.sql
+++ b/supabase/migrations/20250829100600_enable_rls_exercise_tables.sql
@@ -1,0 +1,29 @@
+-- Enable row level security on exercise_sets and exercises
+ALTER TABLE public.exercise_sets ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.exercises ENABLE ROW LEVEL SECURITY;
+
+-- Allow users to manage exercise_sets tied to their workout sessions
+CREATE POLICY "Users can manage own exercise_sets"
+ON public.exercise_sets
+FOR ALL
+USING (
+  EXISTS (
+    SELECT 1 FROM public.workout_sessions ws
+    WHERE ws.id = exercise_sets.workout_id
+      AND ws.user_id = auth.uid()
+  )
+)
+WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM public.workout_sessions ws
+    WHERE ws.id = exercise_sets.workout_id
+      AND ws.user_id = auth.uid()
+  )
+);
+
+-- Allow users to manage exercises they created
+CREATE POLICY "Users can manage own exercises"
+ON public.exercises
+FOR ALL
+USING (auth.uid() = created_by)
+WITH CHECK (auth.uid() = created_by);


### PR DESCRIPTION
## Summary
- enable row level security on `exercise_sets` and `exercises`
- add policies so users can manage their own exercise sets and exercises

## Testing
- `npx supabase gen types typescript --project-id oglcdlzomfuoyeqeobal --schema public` *(fails: Access token not provided)*
- `npm test` *(fails: 8 failed, 54 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b17cd938a88326b11ebab5ccf5dfd9