### PR TITLE
feat: build exercise options from historical sets

### DIFF
--- a/src/services/exerciseOptionsService.ts
+++ b/src/services/exerciseOptionsService.ts
@@ -5,27 +5,54 @@ export interface ExerciseOption {
   name: string;
 }
 
+const cache = new Map<string, ExerciseOption[]>();
+
 export async function getExerciseOptions(userId: string): Promise<ExerciseOption[]> {
+  if (cache.has(userId)) {
+    return cache.get(userId)!;
+  }
+
   const { data, error } = await supabase
     .from('exercise_sets')
-    .select('exercise_id, exercise_name, exercises(name), workout_sessions!inner(user_id)')
-    .eq('workout_sessions.user_id', userId)
-    .not('exercise_id', 'is', null);
+    .select('exercise_id, exercise_name, workout_sessions!inner(user_id)')
+    .eq('workout_sessions.user_id', userId);
 
   if (error) throw error;
 
-  const map = new Map<string, string>();
-  for (const row of data || []) {
-    if (row.exercise_id) {
-      const name =
-        (row as any).exercises?.name ??
-        (row as any).exercise_name ??
-        row.exercise_id;
-      map.set(row.exercise_id, name);
+  const ids = Array.from(
+    new Set((data || []).map(row => row.exercise_id).filter(Boolean) as string[])
+  );
+
+  const idToName = new Map<string, string>();
+  if (ids.length > 0) {
+    const { data: exercises, error: exError } = await supabase
+      .from('exercises')
+      .select('id, name')
+      .in('id', ids);
+    if (exError) throw exError;
+    for (const ex of exercises || []) {
+      idToName.set(ex.id, ex.name);
     }
   }
 
-  return Array.from(map.entries())
-    .map(([id, name]) => ({ id, name }))
-    .sort((a, b) => a.name.localeCompare(b.name));
+  const nameSet = new Set<string>();
+  const options: ExerciseOption[] = [];
+  for (const row of data || []) {
+    const resolvedName =
+      (row.exercise_id && idToName.get(row.exercise_id)) ||
+      row.exercise_name ||
+      row.exercise_id;
+
+    if (!resolvedName || nameSet.has(resolvedName)) continue;
+    nameSet.add(resolvedName);
+
+    options.push({
+      id: row.exercise_id || resolvedName,
+      name: resolvedName,
+    });
+  }
+
+  options.sort((a, b) => a.name.localeCompare(b.name));
+  cache.set(userId, options);
+  return options;
 }


### PR DESCRIPTION
## Summary
- gather distinct exercise names from user's exercise sets
- enrich names with exercise table and cache per user

## Testing
- `npm test` *(fails: unable to find elements / snapshot mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68b17de168a4832685ef13f8863a4547