### PR TITLE
Track exercise IDs in workout set operations

### DIFF
--- a/src/components/AddExerciseBar.tsx
+++ b/src/components/AddExerciseBar.tsx
@@ -21,12 +21,12 @@ export function AddExerciseBar({
 }: AddExerciseBarProps) {
   const isMobile = useIsMobile();
 
-  // Handle selection of exercise and extract name if it's an object
+  // Pass the full exercise object so callers have access to id and name
   const handleSelectExercise = (exercise: string | Exercise) => {
     if (typeof exercise === 'string') {
       onSelectExercise(exercise);
-    } else if (exercise && typeof exercise === 'object' && 'name' in exercise) {
-      onSelectExercise(exercise.name);
+    } else {
+      onSelectExercise(exercise);
     }
   };
 

--- a/src/hooks/useWorkoutDetails.ts
+++ b/src/hooks/useWorkoutDetails.ts
@@ -62,6 +62,7 @@ export function useWorkoutDetails(workoutId: string | undefined) {
           const exerciseName = set.exercise_name;
           const mapped = {
             ...(set as ExerciseSet),
+            exercise_id: set.exercise_id,
             restTime: (set.rest_time ?? null) as number | null,
           } as ExerciseSet;
           if (!acc[exerciseName]) {

--- a/src/types/exercise.ts
+++ b/src/types/exercise.ts
@@ -9,6 +9,7 @@ export interface ExerciseSet {
   set_number: number;
   exercise_name: string;
   workout_id: string;
+  exercise_id?: string;
   weightCalculation?: WeightCalculation;
   metadata?: Record<string, any>; // Add metadata property for RPE and other set-specific data
 }

--- a/src/types/workout.ts
+++ b/src/types/workout.ts
@@ -29,6 +29,7 @@ export type ExerciseSet = {
   id: string;
   workout_id: string;
   exercise_name: string;
+  exercise_id?: string | null;
   weight: number;
   reps: number;
   completed: boolean;

--- a/supabase/migrations/20250901000000_backfill-exercise_sets-exercise-id.sql
+++ b/supabase/migrations/20250901000000_backfill-exercise_sets-exercise-id.sql
@@ -1,0 +1,6 @@
+-- Backfill exercise_id in exercise_sets by matching on exercise_name
+UPDATE exercise_sets es
+SET exercise_id = e.id
+FROM exercises e
+WHERE es.exercise_id IS NULL
+  AND es.exercise_name = e.name;


### PR DESCRIPTION
## Summary
- Include `exercise_id` when inserting or updating exercise sets
- Propagate exercise IDs through exercise management logic and selection bar
- Backfill existing `exercise_sets` with matching IDs

## Testing
- `npm test` *(fails: Snapshots 1 failed, Test Files 2 failed | 12 passed (14), Tests 8 failed | 54 passed (62))*

------
https://chatgpt.com/codex/tasks/task_e_68b19453f9e88326923b0f51f6e7f87d