### PR TITLE
feat: use generated exercise set types

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
     "dev": "vite",
     "build": "vite build",
     "build:dev": "vite build --mode development",
-    "lint": "eslint .",
+    "lint": "npm run check:db-types && eslint .",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run",
+    "check:db-types": "npx supabase gen types typescript --project-id oglcdlzomfuoyeqeobal > /tmp/supabase-types.ts && diff -q /tmp/supabase-types.ts src/integrations/supabase/types.ts && rm /tmp/supabase-types.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/src/hooks/useWorkoutDetails.ts
+++ b/src/hooks/useWorkoutDetails.ts
@@ -3,6 +3,9 @@ import { useState, useEffect } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "@/hooks/use-toast";
 import { ExerciseSet } from "@/types/exercise";
+import type { Database } from "@/integrations/supabase/types";
+
+type DbExerciseSet = Database["public"]["Tables"]["exercise_sets"]["Row"];
 import { restAuditLog, isRestAuditEnabled } from "@/utils/restAudit";
 
 export function useWorkoutDetails(workoutId: string | undefined) {
@@ -33,7 +36,7 @@ export function useWorkoutDetails(workoutId: string | undefined) {
         
         const { data: sets, error: setsError } = await supabase
           .from('exercise_sets')
-          .select('*')
+          .select<DbExerciseSet[]>('*')
           .eq('workout_id', workoutId)
           .order('exercise_name', { ascending: true })
           .order('set_number', { ascending: true });
@@ -58,12 +61,26 @@ export function useWorkoutDetails(workoutId: string | undefined) {
         }
 
         const groupedSets = sets?.reduce<Record<string, ExerciseSet[]>>((acc, raw) => {
-          const set = raw as any;
+          const set = raw as DbExerciseSet;
           const exerciseName = set.exercise_name;
-          const mapped = {
-            ...(set as ExerciseSet),
-            exercise_id: set.exercise_id,
-            restTime: (set.rest_time ?? null) as number | null,
+          const mapped: ExerciseSet = {
+            id: set.id,
+            exercise_name: set.exercise_name,
+            workout_id: set.workout_id,
+            weight: set.weight,
+            reps: set.reps,
+            set_number: set.set_number,
+            completed: set.completed,
+            restTime: set.rest_time ?? undefined,
+            rpe: set.rpe ?? undefined,
+            variant_id: set.variant_id ?? undefined,
+            tempo: set.tempo ?? undefined,
+            range_of_motion: set.range_of_motion ?? undefined,
+            added_weight: set.added_weight ?? undefined,
+            assistance_used: set.assistance_used ?? undefined,
+            notes: set.notes ?? undefined,
+            failurePoint: set.failure_point ?? null,
+            formScore: set.form_score ?? null,
           } as ExerciseSet;
           if (!acc[exerciseName]) {
             acc[exerciseName] = [];

--- a/src/services/exerciseSetService.ts
+++ b/src/services/exerciseSetService.ts
@@ -1,5 +1,8 @@
 
 import { supabase } from "@/integrations/supabase/client";
+import type { Database } from "@/integrations/supabase/types";
+
+type DbExerciseSet = Database["public"]["Tables"]["exercise_sets"]["Row"];
 
 /**
  * Updates or creates sets for an exercise in a workout
@@ -20,11 +23,13 @@ export async function updateExerciseSets(workoutId: string, exerciseId: string |
   added_weight?: number | null;
   assistance_used?: number | null;
   notes?: string | null;
-}[]) {
+  failurePoint?: DbExerciseSet["failure_point"];
+  formScore?: DbExerciseSet["form_score"];
+}[]): Promise<DbExerciseSet[] | null> {
   // Get existing set IDs for this exercise in this workout
   let query = supabase
     .from('exercise_sets')
-    .select('id')
+    .select<Pick<DbExerciseSet, 'id'>[]>('id')
     .eq('workout_id', workoutId)
     .eq('exercise_name', exerciseName);
   if (exerciseId) {
@@ -121,7 +126,7 @@ export async function updateExerciseSets(workoutId: string, exerciseId: string |
   // Fetch the updated sets
   let finalQuery = supabase
     .from('exercise_sets')
-    .select('*')
+    .select<DbExerciseSet[]>('*')
     .eq('workout_id', workoutId)
     .order('set_number', { ascending: true });
   if (exerciseId) {

--- a/src/services/workoutRecoveryService.ts
+++ b/src/services/workoutRecoveryService.ts
@@ -1,5 +1,8 @@
 
 import { supabase } from "@/integrations/supabase/client";
+import type { Database } from "@/integrations/supabase/types";
+
+type DbExerciseSet = Database["public"]["Tables"]["exercise_sets"]["Row"];
 
 /**
  * Restores a deleted workout with its exercise sets
@@ -33,7 +36,7 @@ export async function restoreWorkout(workout: any) {
   // Fetch the original exercise sets for this workout
   const { data: sets, error: fetchError } = await supabase
     .from('exercise_sets')
-    .select('*')
+    .select<DbExerciseSet[]>('*')
     .eq('workout_id', workout.id);
     
   if (fetchError) {
@@ -50,7 +53,17 @@ export async function restoreWorkout(workout: any) {
         weight: set.weight,
         reps: set.reps,
         set_number: set.set_number,
-        completed: set.completed
+        completed: set.completed,
+        rest_time: set.rest_time ?? null,
+        rpe: set.rpe ?? null,
+        variant_id: set.variant_id ?? null,
+        tempo: set.tempo ?? null,
+        range_of_motion: set.range_of_motion ?? null,
+        added_weight: set.added_weight ?? null,
+        assistance_used: set.assistance_used ?? null,
+        notes: set.notes ?? null,
+        failure_point: set.failure_point ?? null,
+        form_score: set.form_score ?? null,
       })));
       
     if (insertError) {


### PR DESCRIPTION
## Summary
- add Supabase type drift check in lint step
- strongly type exercise_sets queries and map new fields
- restore workout sets with full schema support

## Testing
- `npm test` *(fails: Unable to find an element with the text: /Est\. Load @ 80 kg:/. This could be because the text is broken up by multiple elements)*
- `npm run lint` *(fails: Access token not provided. Supply an access token by running supabase login or setting the SUPABASE_ACCESS_TOKEN environment variable.)*

------
https://chatgpt.com/codex/tasks/task_e_68b19bb4b7c8832685509171a7dd661e