### PR TITLE
feat: handle absent workouts in analytics page

### DIFF
--- a/src/pages/analytics/AnalyticsPage.tsx
+++ b/src/pages/analytics/AnalyticsPage.tsx
@@ -7,10 +7,10 @@ import * as FEATURE_FLAGS from '@/constants/featureFlags';
 import { fmtKgPerMin, fmtSeconds, fmtRatio } from './formatters';
 
 export type AnalyticsPageProps = {
-  perWorkout: PerWorkoutMetrics[];
+  perWorkout?: PerWorkoutMetrics[];
 };
 
-export const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ perWorkout }) => {
+export const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ perWorkout = [] }) => {
   const [options, setOptions] = React.useState(getMetricOptions());
   const [metric, setMetric] = React.useState<ChartMetric>(options[0].key);
   React.useEffect(() => {
@@ -24,7 +24,7 @@ export const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ perWorkout }) => {
 
   const series = React.useMemo(() => {
     const adapter = metricToSeries[metric];
-    return adapter ? adapter(perWorkout) : [];
+    return adapter ? adapter(perWorkout ?? []) : [];
   }, [metric, perWorkout]);
 
   // KPI calculations (last 7 days vs previous 7 days)

--- a/src/pages/analytics/__tests__/AnalyticsPage.no-data.test.tsx
+++ b/src/pages/analytics/__tests__/AnalyticsPage.no-data.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { AnalyticsPage } from '../AnalyticsPage';
+
+describe('AnalyticsPage defaults', () => {
+  it('renders without workout data', () => {
+    const { getByTestId } = render(<AnalyticsPage />);
+    expect(getByTestId('series').textContent).toBe('[]');
+  });
+});


### PR DESCRIPTION
## Summary
- default analytics perWorkout to empty list and guard adapter call
- add test verifying analytics page renders with no workout data

## Testing
- `npm test src/pages/analytics/__tests__/AnalyticsPage.no-data.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b1c9671bbc83269aaac0f63591c55d