### PR TITLE
chore: log feature flags and route to new analytics

### DIFF
--- a/src/config/featureFlags.ts
+++ b/src/config/featureFlags.ts
@@ -1,8 +1,9 @@
 // Feature flags for gradual rollout
 export const FEATURE_FLAGS = {
   // Analytics derived KPIs (density, rest time analysis, set efficiency)
-  ANALYTICS_DERIVED_KPIS_ENABLED: process.env.NODE_ENV === 'development' || 
+  ANALYTICS_DERIVED_KPIS_ENABLED: process.env.NODE_ENV === 'development' ||
     process.env.VITE_ANALYTICS_DERIVED_KPIS === 'true',
-    
+
   // Other existing flags can be added here
 } as const;
+console.debug('[config/featureFlags] ANALYTICS_DERIVED_KPIS_ENABLED=', FEATURE_FLAGS.ANALYTICS_DERIVED_KPIS_ENABLED);

--- a/src/constants/featureFlags.ts
+++ b/src/constants/featureFlags.ts
@@ -4,3 +4,9 @@ export const SETUP_CHOOSE_EXERCISES_ENABLED =
 // Gate for derived analytics KPIs (density, avg rest, set efficiency)
 export const ANALYTICS_DERIVED_KPIS_ENABLED =
   (import.meta.env.DEV || import.meta.env.VITE_ANALYTICS_DERIVED_KPIS === 'true');
+console.debug('[featureFlags] ANALYTICS_DERIVED_KPIS_ENABLED=', ANALYTICS_DERIVED_KPIS_ENABLED);
+
+export const FEATURE_FLAGS = {
+  SETUP_CHOOSE_EXERCISES_ENABLED,
+  ANALYTICS_DERIVED_KPIS_ENABLED,
+} as const;

--- a/src/context/RouterProvider.tsx
+++ b/src/context/RouterProvider.tsx
@@ -13,7 +13,7 @@ import ProfilePage from "@/pages/ProfilePage";
 import Auth from "@/pages/Auth";
 import AllExercisesPage from "@/pages/AllExercisesPage";
 import Overview from "@/pages/Overview";
-import Analytics from "@/pages/Analytics";
+import AnalyticsPage from "@/pages/analytics/AnalyticsPage";
 import { FEATURE_FLAGS } from "@/config/flags";
 import { WorkoutManagementPage } from "@/pages/WorkoutManagementPage";
 import EnhancedTrainingCoachPage from "@/pages/EnhancedTrainingCoachPage";
@@ -35,6 +35,7 @@ const ProtectedRoute = ({ children }: { children: React.ReactNode }) => {
 export const RouterProvider = () => {
   const location = useLocation();
   const isAuthPage = location.pathname === "/auth";
+  console.debug('[RouterProvider] KPI_ANALYTICS_ENABLED=', FEATURE_FLAGS.KPI_ANALYTICS_ENABLED);
 
   return (
     <WorkoutNavigationContextProvider>
@@ -66,7 +67,8 @@ export const RouterProvider = () => {
                 element={
                   <ProtectedRoute>
                     <MainLayout>
-                      <Analytics />
+                      {console.debug('[RouterProvider] rendering AnalyticsPage')}
+                      <AnalyticsPage />
                     </MainLayout>
                   </ProtectedRoute>
                 }

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -19,6 +19,9 @@ import ExerciseFeedbackTrends from '@/components/analytics/ExerciseFeedbackTrend
 // import { useUserExercises } from '@/hooks/useUserExercises';
 
 const Analytics: React.FC = () => {
+  React.useEffect(() => {
+    console.debug('[LegacyAnalytics] render');
+  }, []);
   const { dateRange } = useDateRange();
   const { user } = useAuth();
   const location = useLocation();

--- a/src/pages/analytics/AnalyticsPage.tsx
+++ b/src/pages/analytics/AnalyticsPage.tsx
@@ -10,6 +10,9 @@ export type AnalyticsPageProps = {
 
 export const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ perWorkout = [] }) => {
   const { flags } = useConfig();
+  React.useEffect(() => {
+    console.debug('[AnalyticsPage] render, derivedKpis=', flags.derivedKpis);
+  }, [flags.derivedKpis]);
   const initOpts = React.useMemo(() => availableMetrics({ derivedKpis: flags.derivedKpis }), [flags.derivedKpis]);
   const [options, setOptions] = React.useState(initOpts);
   const [metric, setMetric] = React.useState<ChartMetric>(initOpts[0].key);


### PR DESCRIPTION
## Summary
- route KPI Analytics tab to new AnalyticsPage and log when rendered
- log derived KPI feature flag value in both runtime configs
- add debug output to legacy Analytics page for comparison

## Testing
- `npm test` *(fails: TypeError: this.client.from is not a function)*
- `npx vitest run src/pages/analytics/__tests__/MetricSelector.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b1f1751a5c8326a02e2e7bf02afa50