### PR TITLE
fix: stabilize metrics query

### DIFF
--- a/src/hooks/useMetricsV2.ts
+++ b/src/hooks/useMetricsV2.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
 import { metricsServiceV2 } from '@/services/metrics-v2/service';
 import type { AnalyticsServiceData } from '@/pages/analytics/AnalyticsPage';
 
@@ -7,16 +8,30 @@ import type { AnalyticsServiceData } from '@/pages/analytics/AnalyticsPage';
  * The query is disabled when no user id is provided.
  */
 export function useMetricsV2(userId?: string) {
-  const now = new Date();
-  const start = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000); // last 30 days
+  const { start, end } = useMemo(() => {
+    const endDate = new Date();
+    const startDate = new Date(endDate.getTime() - 30 * 24 * 60 * 60 * 1000); // last 30 days
+    return { start: startDate, end: endDate };
+  }, []);
+
+  const range = useMemo(
+    () => ({
+      start: start.toISOString(),
+      end: end.toISOString(),
+    }),
+    [start.getTime(), end.getTime()]
+  );
+
   return useQuery<AnalyticsServiceData>({
-    queryKey: ['metrics-v2', userId, start.toISOString(), now.toISOString()],
+    queryKey: ['metrics-v2', userId, range.start, range.end],
     queryFn: () =>
       metricsServiceV2.getMetricsV2({
         userId: userId!,
-        dateRange: { start: start.toISOString(), end: now.toISOString() },
+        dateRange: range,
       }) as Promise<AnalyticsServiceData>,
     enabled: !!userId,
+    staleTime: 60000,
+    refetchOnWindowFocus: false,
   });
 }
 


### PR DESCRIPTION
## Summary
- memoize date range and stabilize React Query key for metrics-v2
- add caching options to reduce refetching

## Testing
- `npm test` *(fails: No QueryClient set; Supabase client.from is not a function)*
- `npm run lint` *(fails: supabase CLI/gen types step)*

------
https://chatgpt.com/codex/tasks/task_e_68b301191e6c832693269e9fbda4072d