### PR TITLE
feat: add runtime feature flags and analytics date range

### DIFF
--- a/src/config/featureFlags.ts
+++ b/src/config/featureFlags.ts
@@ -1,9 +1,0 @@
-// Feature flags for gradual rollout
-export const FEATURE_FLAGS = {
-  // Analytics derived KPIs (density, rest time analysis, set efficiency)
-  ANALYTICS_DERIVED_KPIS_ENABLED: process.env.NODE_ENV === 'development' ||
-    process.env.VITE_ANALYTICS_DERIVED_KPIS === 'true',
-
-  // Other existing flags can be added here
-} as const;
-console.debug('[config/featureFlags] ANALYTICS_DERIVED_KPIS_ENABLED=', FEATURE_FLAGS.ANALYTICS_DERIVED_KPIS_ENABLED);

--- a/src/constants/featureFlags.ts
+++ b/src/constants/featureFlags.ts
@@ -1,20 +1,84 @@
-export const SETUP_CHOOSE_EXERCISES_ENABLED =
-  (import.meta.env.VITE_SETUP_CHOOSE_EXERCISES_ENABLED ?? 'true') === 'true';
+export type FlagName =
+  | 'ANALYTICS_DERIVED_KPIS_ENABLED'
+  | 'KPI_ANALYTICS_ENABLED'
+  | 'SET_COMPLETE_NOTIFICATIONS_ENABLED'
+  | 'SETUP_CHOOSE_EXERCISES_ENABLED';
 
-// Gate for derived analytics KPIs (density, avg rest, set efficiency)
-export const ANALYTICS_DERIVED_KPIS_ENABLED =
-  (import.meta.env.DEV || import.meta.env.VITE_ANALYTICS_DERIVED_KPIS === 'true');
-console.debug('[featureFlags] ANALYTICS_DERIVED_KPIS_ENABLED=', ANALYTICS_DERIVED_KPIS_ENABLED);
+const defaults: Record<FlagName, boolean> = {
+  ANALYTICS_DERIVED_KPIS_ENABLED: import.meta.env.DEV,
+  KPI_ANALYTICS_ENABLED: true,
+  SET_COMPLETE_NOTIFICATIONS_ENABLED: false,
+  SETUP_CHOOSE_EXERCISES_ENABLED:
+    (import.meta.env.VITE_SETUP_CHOOSE_EXERCISES_ENABLED ?? 'true') === 'true',
+};
 
-export const SET_COMPLETE_NOTIFICATIONS_ENABLED =
-  (import.meta.env.VITE_SET_COMPLETE_NOTIFICATIONS_ENABLED ?? 'false') === 'true';
-console.debug(
-  '[featureFlags] SET_COMPLETE_NOTIFICATIONS_ENABLED=',
-  SET_COMPLETE_NOTIFICATIONS_ENABLED,
-);
+const overrides: Partial<Record<FlagName, boolean>> = {};
+
+function readLocal(name: FlagName): boolean | undefined {
+  if (typeof window === 'undefined') return undefined;
+  const v = window.localStorage.getItem(name);
+  return v === null ? undefined : v === 'true';
+}
+
+function readEnv(name: FlagName): boolean | undefined {
+  const envKey = `VITE_${name}`;
+  const raw = (import.meta as any).env?.[envKey];
+  return typeof raw === 'string' ? raw === 'true' : undefined;
+}
+
+export function getFlag(name: FlagName, def: boolean = defaults[name]): boolean {
+  if (overrides[name] !== undefined) return overrides[name] as boolean;
+  const local = readLocal(name);
+  if (local !== undefined) return local;
+  const env = readEnv(name);
+  if (env !== undefined) return env;
+  return def;
+}
+
+export function setFlagOverride(name: FlagName, value: boolean) {
+  overrides[name] = value;
+  if (typeof window !== 'undefined') {
+    try {
+      window.localStorage.setItem(name, String(value));
+      (window as any).__FLAGS__ = {
+        ...(window as any).__FLAGS__,
+        [name]: value,
+      };
+    } catch {
+      // ignore
+    }
+  }
+}
 
 export const FEATURE_FLAGS = {
-  SETUP_CHOOSE_EXERCISES_ENABLED,
-  ANALYTICS_DERIVED_KPIS_ENABLED,
-  SET_COMPLETE_NOTIFICATIONS_ENABLED,
+  get ANALYTICS_DERIVED_KPIS_ENABLED() {
+    return getFlag('ANALYTICS_DERIVED_KPIS_ENABLED');
+  },
+  set ANALYTICS_DERIVED_KPIS_ENABLED(v: boolean) {
+    setFlagOverride('ANALYTICS_DERIVED_KPIS_ENABLED', v);
+  },
+  get KPI_ANALYTICS_ENABLED() {
+    return getFlag('KPI_ANALYTICS_ENABLED');
+  },
+  set KPI_ANALYTICS_ENABLED(v: boolean) {
+    setFlagOverride('KPI_ANALYTICS_ENABLED', v);
+  },
+  get SET_COMPLETE_NOTIFICATIONS_ENABLED() {
+    return getFlag('SET_COMPLETE_NOTIFICATIONS_ENABLED');
+  },
+  set SET_COMPLETE_NOTIFICATIONS_ENABLED(v: boolean) {
+    setFlagOverride('SET_COMPLETE_NOTIFICATIONS_ENABLED', v);
+  },
+  get SETUP_CHOOSE_EXERCISES_ENABLED() {
+    return getFlag('SETUP_CHOOSE_EXERCISES_ENABLED');
+  },
+  set SETUP_CHOOSE_EXERCISES_ENABLED(v: boolean) {
+    setFlagOverride('SETUP_CHOOSE_EXERCISES_ENABLED', v);
+  },
 } as const;
+
+const bootLine =
+  `[featureFlags] ANALYTICS_DERIVED_KPIS_ENABLED=${FEATURE_FLAGS.ANALYTICS_DERIVED_KPIS_ENABLED} ` +
+  `KPI_ANALYTICS_ENABLED=${FEATURE_FLAGS.KPI_ANALYTICS_ENABLED} ` +
+  `SET_COMPLETE_NOTIFICATIONS_ENABLED=${FEATURE_FLAGS.SET_COMPLETE_NOTIFICATIONS_ENABLED}`;
+console.debug(bootLine);

--- a/src/hooks/useMetricsV2.ts
+++ b/src/hooks/useMetricsV2.ts
@@ -1,38 +1,27 @@
 import { useQuery } from '@tanstack/react-query';
-import { useMemo } from 'react';
 import { metricsServiceV2 } from '@/services/metrics-v2/service';
 import type { AnalyticsServiceData } from '@/pages/analytics/AnalyticsPage';
 
-/**
- * Fetch metrics-v2 data for the current user.
- * The query is disabled when no user id is provided.
- */
-export function useMetricsV2(userId?: string) {
-  const { start, end } = useMemo(() => {
-    const endDate = new Date();
-    const startDate = new Date(endDate.getTime() - 30 * 24 * 60 * 60 * 1000); // last 30 days
-    return { start: startDate, end: endDate };
-  }, []);
+interface RangeParams {
+  startISO: string;
+  endISO: string;
+  includeBodyweightLoads: boolean;
+}
 
-  const range = useMemo(
-    () => ({
-      start: start.toISOString(),
-      end: end.toISOString(),
-    }),
-    [start.getTime(), end.getTime()]
-  );
-
+export default function useMetricsV2(
+  userId?: string,
+  range?: RangeParams
+) {
   return useQuery<AnalyticsServiceData>({
-    queryKey: ['metrics-v2', userId, range.start, range.end],
+    queryKey: ['metricsV2', userId, range?.startISO, range?.endISO, range?.includeBodyweightLoads],
     queryFn: () =>
       metricsServiceV2.getMetricsV2({
         userId: userId!,
-        dateRange: range,
+        dateRange: { start: range!.startISO, end: range!.endISO },
+        includeBodyweightLoads: range?.includeBodyweightLoads,
       }) as Promise<AnalyticsServiceData>,
-    enabled: !!userId,
+    enabled: !!userId && !!range,
     staleTime: 60000,
     refetchOnWindowFocus: false,
   });
 }
-
-export default useMetricsV2;

--- a/src/pages/analytics/__tests__/AnalyticsPage.flag.test.tsx
+++ b/src/pages/analytics/__tests__/AnalyticsPage.flag.test.tsx
@@ -2,51 +2,42 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { ConfigProvider } from '@/config/runtimeConfig';
-import { FEATURE_FLAGS } from '@/constants/featureFlags';
 import { AnalyticsPage } from '../AnalyticsPage';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 // counts renders based on console.debug log emitted by AnalyticsPage
 
 describe('AnalyticsPage render with derived KPI feature flag', () => {
-  it('renders a finite number of times when ANALYTICS_DERIVED_KPIS_ENABLED toggles', () => {
-    const original = FEATURE_FLAGS.ANALYTICS_DERIVED_KPIS_ENABLED;
+  it('renders a finite number of times when flag toggles', () => {
     const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     let renderCalls = 0;
     let errorCalls = 0;
-    try {
-      // initial render with flag enabled
-      (FEATURE_FLAGS as any).ANALYTICS_DERIVED_KPIS_ENABLED = true;
-      const client = new QueryClient();
-      const { rerender } = render(
-        <QueryClientProvider client={client}>
-          <ConfigProvider initialFlags={{ derivedKpis: FEATURE_FLAGS.ANALYTICS_DERIVED_KPIS_ENABLED }}>
-            <AnalyticsPage data={{ metricKeys: [] }} />
-          </ConfigProvider>
-        </QueryClientProvider>
-      );
+    const client = new QueryClient();
+    const { rerender } = render(
+      <QueryClientProvider client={client}>
+        <ConfigProvider initialFlags={{ derivedKpis: true }}>
+          <AnalyticsPage data={{ metricKeys: [] }} />
+        </ConfigProvider>
+      </QueryClientProvider>
+    );
 
-      // toggle flag and rerender
-      (FEATURE_FLAGS as any).ANALYTICS_DERIVED_KPIS_ENABLED = false;
-      rerender(
-        <QueryClientProvider client={client}>
-          <ConfigProvider initialFlags={{ derivedKpis: FEATURE_FLAGS.ANALYTICS_DERIVED_KPIS_ENABLED }}>
-            <AnalyticsPage data={{ metricKeys: [] }} />
-          </ConfigProvider>
-        </QueryClientProvider>
-      );
+    rerender(
+      <QueryClientProvider client={client}>
+        <ConfigProvider initialFlags={{ derivedKpis: false }}>
+          <AnalyticsPage data={{ metricKeys: [] }} />
+        </ConfigProvider>
+      </QueryClientProvider>
+    );
 
-      renderCalls = debugSpy.mock.calls.filter((args) =>
-        typeof args[0] === 'string' && args[0].includes('[AnalyticsPage] render')
-      ).length;
-      errorCalls = errorSpy.mock.calls.length;
-    } finally {
-      (FEATURE_FLAGS as any).ANALYTICS_DERIVED_KPIS_ENABLED = original;
-      debugSpy.mockRestore();
-      errorSpy.mockRestore();
-    }
+    renderCalls = debugSpy.mock.calls.filter((args) =>
+      typeof args[0] === 'string' && args[0].includes('[AnalyticsPage] render')
+    ).length;
+    errorCalls = errorSpy.mock.calls.length;
+
+    debugSpy.mockRestore();
+    errorSpy.mockRestore();
 
     expect(renderCalls).toBe(2);
     expect(errorCalls).toBe(0);

--- a/src/pages/analytics/__tests__/__snapshots__/AnalyticsPage.snap.test.tsx.snap
+++ b/src/pages/analytics/__tests__/__snapshots__/AnalyticsPage.snap.test.tsx.snap
@@ -3,12 +3,41 @@
 exports[`AnalyticsPage KPI cards > renders KPI cards when enabled 1`] = `
 <div>
   <div>
-    <div
-      class="flex gap-4 mb-4"
-    >
-      <div
-        data-testid="kpi-density"
-      >
+    <div class="flex items-center justify-between mb-4">
+      <label class="flex items-center gap-2">
+        <input
+          checked=""
+          title="Adds Density, Efficiency, PRs, and other computed metrics (Metrics v2)."
+          type="checkbox"
+        />
+        <span>
+          Show derived KPIs (beta)
+        </span>
+      </label>
+      <div class="flex items-center gap-2">
+        <select
+          data-testid="range-select"
+        >
+          <option value="last7">
+            Last 7 days
+          </option>
+          <option value="last14">
+            Last 14 days
+          </option>
+          <option value="last30">
+            Last 30 days
+          </option>
+          <option value="thisMonth">
+            This month
+          </option>
+          <option value="custom">
+            Custom
+          </option>
+        </select>
+      </div>
+    </div>
+    <div class="flex gap-4 mb-4">
+      <div data-testid="kpi-density">
         <div>
           Density
         </div>
@@ -19,9 +48,7 @@ exports[`AnalyticsPage KPI cards > renders KPI cards when enabled 1`] = `
           +10.00 kg/min
         </div>
       </div>
-      <div
-        data-testid="kpi-rest"
-      >
+      <div data-testid="kpi-rest">
         <div>
           Avg Rest
         </div>
@@ -32,9 +59,7 @@ exports[`AnalyticsPage KPI cards > renders KPI cards when enabled 1`] = `
           -0m 30s
         </div>
       </div>
-      <div
-        data-testid="kpi-efficiency"
-      >
+      <div data-testid="kpi-efficiency">
         <div>
           Set Efficiency
         </div>
@@ -49,50 +74,32 @@ exports[`AnalyticsPage KPI cards > renders KPI cards when enabled 1`] = `
     <select
       data-testid="metric-select"
     >
-      <option
-        value="volume"
-      >
-        Total Volume
+      <option value="volume">
+        Tonnage (kg)
       </option>
-      <option
-        value="sets"
-      >
-        Total Sets
+      <option value="sets">
+        Sets
       </option>
-      <option
-        value="workouts"
-      >
+      <option value="workouts">
         Workouts
       </option>
-      <option
-        value="duration"
-      >
-        Total Duration
+      <option value="duration">
+        Duration (min)
       </option>
-      <option
-        value="reps"
-      >
-        Total Reps
+      <option value="reps">
+        Reps
       </option>
-      <option
-        value="density"
-      >
-        Workout Density (kg/min)
+      <option value="density">
+        Density (kg/min)
       </option>
-      <option
-        value="avgRest"
-      >
+      <option value="avgRest">
         Avg Rest / Session (sec)
       </option>
-      <option
-        value="setEfficiency"
-      >
+      <option value="setEfficiency">
         Set Efficiency (×)
       </option>
     </select>
-    <div
-      data-testid="empty-series"
-    >
+    <div data-testid="empty-series">
       No data to display
     </div>
   </div>

--- a/src/pages/analytics/metricOptions.ts
+++ b/src/pages/analytics/metricOptions.ts
@@ -1,12 +1,10 @@
-import { ANALYTICS_DERIVED_KPIS_ENABLED } from '@/constants/featureFlags';
-
 const METRIC_LABELS: Record<string, string> = {
-  volume: 'Total Volume',
-  sets: 'Total Sets',
+  volume: 'Tonnage (kg)',
+  sets: 'Sets',
   workouts: 'Workouts',
-  duration: 'Total Duration',
-  reps: 'Total Reps',
-  density: 'Workout Density (kg/min)',
+  duration: 'Duration (min)',
+  reps: 'Reps',
+  density: 'Density (kg/min)',
   avgRest: 'Avg Rest / Session (sec)',
   setEfficiency: 'Set Efficiency (×)',
 };
@@ -19,7 +17,7 @@ export type MetricOption = { key: string; label: string };
  * Build metric options from service-provided metric keys.
  * @deprecated legacy metric constants should no longer be used
  */
-export function buildMetricOptions(keys: string[], derivedEnabled: boolean = ANALYTICS_DERIVED_KPIS_ENABLED): MetricOption[] {
+export function buildMetricOptions(keys: string[], derivedEnabled: boolean): MetricOption[] {
   return keys
     .filter(key => (derivedEnabled ? true : !DERIVED_KEYS.includes(key)))
     .map(key => ({ key, label: METRIC_LABELS[key] || key }));

--- a/src/pages/analytics/metrics.ts
+++ b/src/pages/analytics/metrics.ts
@@ -3,16 +3,16 @@ import type { ChartMetric, MetricOption } from './types';
 
 /** @deprecated Use metricKeys from service instead */
 export const BASE_METRICS: MetricOption[] = [
-  { key: 'volume',   label: 'Total Volume' },
-  { key: 'sets',     label: 'Total Sets' },
+  { key: 'volume',   label: 'Tonnage (kg)' },
+  { key: 'sets',     label: 'Sets' },
   { key: 'workouts', label: 'Workouts' },
-  { key: 'duration', label: 'Total Duration' },
-  { key: 'reps',     label: 'Total Reps' },
+  { key: 'duration', label: 'Duration (min)' },
+  { key: 'reps',     label: 'Reps' },
 ];
 
 /** @deprecated Use metricKeys from service instead */
 export const DERIVED_METRICS: MetricOption[] = [
-  { key: 'density',       label: 'Workout Density (kg/min)' },
+  { key: 'density',       label: 'Density (kg/min)' },
   { key: 'avgRest',       label: 'Avg Rest / Session (sec)' },
   { key: 'setEfficiency', label: 'Set Efficiency (×)' },
 ];

--- a/src/services/metrics-v2/__tests__/aggregators.test.ts
+++ b/src/services/metrics-v2/__tests__/aggregators.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { aggregatePerWorkout, aggregateTotals, aggregateTotalsKpis } from '../aggregators';
 import { WorkoutRaw, SetRaw } from '../types';
-import { FEATURE_FLAGS } from '@/config/featureFlags';
+import { FEATURE_FLAGS } from '@/constants/featureFlags';
 
 // Mock feature flag
 const originalFlag = FEATURE_FLAGS.ANALYTICS_DERIVED_KPIS_ENABLED;

--- a/src/services/metrics-v2/__tests__/integration.test.ts
+++ b/src/services/metrics-v2/__tests__/integration.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { metricsServiceV2 } from '../service';
-import { FEATURE_FLAGS } from '@/config/featureFlags';
+import { FEATURE_FLAGS } from '@/constants/featureFlags';
 
 // Mock feature flag
 const originalFlag = FEATURE_FLAGS.ANALYTICS_DERIVED_KPIS_ENABLED;

--- a/src/services/metrics-v2/aggregators.ts
+++ b/src/services/metrics-v2/aggregators.ts
@@ -7,7 +7,7 @@ import {
   calcSetEfficiency, 
   getTargetRestSecForWorkout 
 } from './calculators/derivedKpis';
-import { FEATURE_FLAGS } from '@/config/featureFlags';
+import { FEATURE_FLAGS } from '@/constants/featureFlags';
 
 export function aggregatePerWorkout(
   workouts: WorkoutRaw[], 


### PR DESCRIPTION
## Summary
- add runtime-overridable feature flag utility with boot-time logging
- expose derived KPI toggle and date range picker on analytics page
- align metrics v2 queries with bodyweight load inclusion and friendly metric labels

## Testing
- `npm test` *(fails: this.client.from is not a function)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b3037f2eb08326870ccf1292de9c1f