### PR TITLE
feat: add derived KPI metrics to metrics v2

### DIFF
--- a/src/hooks/__tests__/useMetricsV2.test.tsx
+++ b/src/hooks/__tests__/useMetricsV2.test.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { renderHook } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { describe, it, expect, vi } from 'vitest';
+import { FEATURE_FLAGS } from '@/constants/featureFlags';
+import { DEFS_VERSION } from '@/services/metrics-v2/registry';
 
 vi.mock('@/services/metrics-v2/service', () => ({
   metricsServiceV2: {
@@ -18,6 +20,7 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
 
 describe('useMetricsV2', () => {
   it('uses stable query key', () => {
+    (FEATURE_FLAGS as any).ANALYTICS_DERIVED_KPIS_ENABLED = true;
     const params = { startISO: '2024-01-01', endISO: '2024-01-07', includeBodyweightLoads: undefined };
     renderHook(() => useMetricsV2('u1', params), { wrapper });
     const queries = client.getQueryCache().getAll();
@@ -25,7 +28,8 @@ describe('useMetricsV2', () => {
       'metricsV2',
       params.startISO,
       params.endISO,
-      params.includeBodyweightLoads,
+      true,
+      DEFS_VERSION,
     ]);
   });
 });

--- a/src/hooks/useMetricsV2.ts
+++ b/src/hooks/useMetricsV2.ts
@@ -1,6 +1,8 @@
 import { useQuery } from '@tanstack/react-query';
 import { metricsServiceV2 } from '@/services/metrics-v2/service';
 import type { AnalyticsServiceData } from '@/pages/analytics/AnalyticsPage';
+import { FEATURE_FLAGS } from '@/constants/featureFlags';
+import { DEFS_VERSION } from '@/services/metrics-v2/registry';
 
 interface RangeParams {
   startISO: string;
@@ -12,19 +14,22 @@ export default function useMetricsV2(
   userId?: string,
   range?: RangeParams
 ) {
+  const includeBodyweight = range?.includeBodyweightLoads ?? FEATURE_FLAGS.ANALYTICS_DERIVED_KPIS_ENABLED;
+  const startISO = range?.startISO;
+  const endISO = range?.endISO;
   return useQuery<AnalyticsServiceData>({
-    queryKey: ['metricsV2', range?.startISO, range?.endISO, range?.includeBodyweightLoads],
+    queryKey: ['metricsV2', startISO, endISO, includeBodyweight, DEFS_VERSION],
     queryFn: () => {
       console.debug('[MetricsV2][debug] params', {
-        startISO: range!.startISO,
-        endISO: range!.endISO,
-        includeBodyweightLoads: range?.includeBodyweightLoads,
+        startISO,
+        endISO,
+        includeBodyweightLoads: includeBodyweight,
       });
       return metricsServiceV2
         .getMetricsV2({
           userId: userId!,
-          dateRange: { start: range!.startISO, end: range!.endISO },
-          includeBodyweightLoads: range?.includeBodyweightLoads,
+          dateRange: { start: startISO!, end: endISO! },
+          includeBodyweightLoads: includeBodyweight,
         })
         .then((res: any) => {
           const points = res?.series?.volume?.length || 0;
@@ -32,7 +37,7 @@ export default function useMetricsV2(
           return res as AnalyticsServiceData;
         });
     },
-    enabled: !!userId && !!range,
+    enabled: !!userId && !!startISO && !!endISO,
     staleTime: 60000,
     refetchOnWindowFocus: false,
   });

--- a/src/pages/analytics/__tests__/AnalyticsPage.no-data.test.tsx
+++ b/src/pages/analytics/__tests__/AnalyticsPage.no-data.test.tsx
@@ -3,13 +3,16 @@ import { render } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AnalyticsPage } from '../AnalyticsPage';
+import { TooltipProvider } from '@/components/ui/tooltip';
 
 describe('AnalyticsPage defaults', () => {
   it('renders without workout data', () => {
     const client = new QueryClient();
     const { getByTestId } = render(
       <QueryClientProvider client={client}>
-        <AnalyticsPage />
+        <TooltipProvider>
+          <AnalyticsPage />
+        </TooltipProvider>
       </QueryClientProvider>
     );
     expect(getByTestId('metric-select')).toBeDisabled();

--- a/src/pages/analytics/__tests__/AnalyticsPage.snap.test.tsx
+++ b/src/pages/analytics/__tests__/AnalyticsPage.snap.test.tsx
@@ -5,6 +5,8 @@ import type { PerWorkoutMetrics, TimeSeriesPoint } from '@/services/metrics-v2/d
 import { FEATURE_FLAGS } from '@/constants/featureFlags';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AnalyticsPage } from '../AnalyticsPage';
+import { TooltipProvider } from '@/components/ui/tooltip';
+
 const makeWorkouts = (): PerWorkoutMetrics[] => {
   const workouts: PerWorkoutMetrics[] = [];
   for (let i = 1; i <= 7; i++) {
@@ -39,14 +41,21 @@ describe('AnalyticsPage KPI cards', () => {
     const workouts = makeWorkouts();
     const data = {
       perWorkout: workouts,
-      series: { volume: [], sets: [], workouts: [], duration: [], reps: [], density: [], avgRest: [], setEfficiency: [] } as Record<string, TimeSeriesPoint[]>,
+      totals: {
+        density_kg_min: 15,
+        avg_rest_ms: 60000,
+        set_efficiency_pct: 80,
+      },
+      series: { volume: [], sets: [], workouts: [], duration: [], reps: [], density_kg_min: [], avg_rest_ms: [], set_efficiency_pct: [] } as Record<string, TimeSeriesPoint[]>,
       metricKeys: ['volume','sets','workouts','duration','reps','density','avgRest','setEfficiency'],
     };
     (FEATURE_FLAGS as any).ANALYTICS_DERIVED_KPIS_ENABLED = true;
     const client = new QueryClient();
     const { container, getByTestId } = render(
       <QueryClientProvider client={client}>
-        <AnalyticsPage data={data} />
+        <TooltipProvider>
+          <AnalyticsPage data={data} />
+        </TooltipProvider>
       </QueryClientProvider>
     );
     expect(getByTestId('kpi-density')).toBeTruthy();
@@ -57,14 +66,21 @@ describe('AnalyticsPage KPI cards', () => {
     const workouts = makeWorkouts();
     const data = {
       perWorkout: workouts,
-      series: { volume: [], sets: [], workouts: [], duration: [], reps: [], density: [], avgRest: [], setEfficiency: [] } as Record<string, TimeSeriesPoint[]>,
+      totals: {
+        density_kg_min: 15,
+        avg_rest_ms: 60000,
+        set_efficiency_pct: 80,
+      },
+      series: { volume: [], sets: [], workouts: [], duration: [], reps: [], density_kg_min: [], avg_rest_ms: [], set_efficiency_pct: [] } as Record<string, TimeSeriesPoint[]>,
       metricKeys: ['volume','sets','workouts','duration','reps','density','avgRest','setEfficiency'],
     };
     (FEATURE_FLAGS as any).ANALYTICS_DERIVED_KPIS_ENABLED = false;
     const client = new QueryClient();
     const { queryByTestId } = render(
       <QueryClientProvider client={client}>
-        <AnalyticsPage data={data} />
+        <TooltipProvider>
+          <AnalyticsPage data={data} />
+        </TooltipProvider>
       </QueryClientProvider>
     );
     expect(queryByTestId('kpi-density')).toBeNull();

--- a/src/pages/analytics/__tests__/__snapshots__/AnalyticsPage.snap.test.tsx.snap
+++ b/src/pages/analytics/__tests__/__snapshots__/AnalyticsPage.snap.test.tsx.snap
@@ -3,103 +3,149 @@
 exports[`AnalyticsPage KPI cards > renders KPI cards when enabled 1`] = `
 <div>
   <div>
-    <div class="flex items-center justify-between mb-4">
-      <label class="flex items-center gap-2">
-        <input
-          checked=""
-          title="Adds Density, Efficiency, PRs, and other computed metrics (Metrics v2)."
-          type="checkbox"
-        />
-        <span>
+    <div
+      class="flex items-center justify-between mb-4"
+    >
+      <div
+        class="flex items-center gap-2"
+      >
+        <button
+          aria-checked="true"
+          class="peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input"
+          data-state="checked"
+          id="derived-toggle"
+          role="switch"
+          type="button"
+          value="on"
+        >
+          <span
+            class="pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0"
+            data-state="checked"
+          />
+        </button>
+        <label
+          class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer"
+          data-state="closed"
+          for="derived-toggle"
+        >
           Show derived KPIs (beta)
-        </span>
-      </label>
-      <div class="flex items-center gap-2">
+        </label>
+      </div>
+      <div
+        class="flex items-center gap-2"
+      >
         <select
           data-testid="range-select"
         >
-          <option value="last7">
+          <option
+            value="last7"
+          >
             Last 7 days
           </option>
-          <option value="last14">
+          <option
+            value="last14"
+          >
             Last 14 days
           </option>
-          <option value="last30">
+          <option
+            value="last30"
+          >
             Last 30 days
           </option>
-          <option value="thisMonth">
+          <option
+            value="thisMonth"
+          >
             This month
           </option>
-          <option value="custom">
+          <option
+            value="custom"
+          >
             Custom
           </option>
         </select>
       </div>
     </div>
-    <div class="flex gap-4 mb-4">
-      <div data-testid="kpi-density">
+    <div
+      class="flex gap-4 mb-4"
+    >
+      <div
+        data-testid="kpi-density"
+      >
         <div>
-          Density
+          Density (kg/min)
         </div>
         <div>
-          20.00 kg/min
-        </div>
-        <div>
-          +10.00 kg/min
+          15.00 kg/min
         </div>
       </div>
-      <div data-testid="kpi-rest">
+      <div
+        data-testid="kpi-rest"
+      >
         <div>
           Avg Rest
         </div>
         <div>
-          0m 30s
-        </div>
-        <div>
-          -0m 30s
+          1m 0s
         </div>
       </div>
-      <div data-testid="kpi-efficiency">
+      <div
+        data-testid="kpi-efficiency"
+      >
         <div>
           Set Efficiency
         </div>
         <div>
           0.80×
         </div>
-        <div>
-          -0.20×
-        </div>
       </div>
     </div>
     <select
       data-testid="metric-select"
     >
-      <option value="volume">
+      <option
+        value="volume"
+      >
         Tonnage (kg)
       </option>
-      <option value="sets">
+      <option
+        value="sets"
+      >
         Sets
       </option>
-      <option value="workouts">
+      <option
+        value="workouts"
+      >
         Workouts
       </option>
-      <option value="duration">
+      <option
+        value="duration"
+      >
         Duration (min)
       </option>
-      <option value="reps">
+      <option
+        value="reps"
+      >
         Reps
       </option>
-      <option value="density">
+      <option
+        value="density"
+      >
         Density (kg/min)
       </option>
-      <option value="avgRest">
+      <option
+        value="avgRest"
+      >
         Avg Rest / Session (sec)
       </option>
-      <option value="setEfficiency">
+      <option
+        value="setEfficiency"
+      >
         Set Efficiency (×)
       </option>
     </select>
-    <div data-testid="empty-series">
+    <div
+      data-testid="empty-series"
+    >
       No data to display
     </div>
   </div>

--- a/src/services/metrics-v2/__tests__/engine.calculators.test.ts
+++ b/src/services/metrics-v2/__tests__/engine.calculators.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getSetLoadKg,
+  deriveRestMs,
+  calcDensityKgPerMin,
+  calcAvgRestMs,
+  calcSetEfficiencyPct,
+} from '../engine/calculators';
+
+const ctx = { includeBodyweight: true, bodyweightKg: 80 };
+
+describe('engine calculators', () => {
+  it('getSetLoadKg handles weighted, bodyweight and mixed', () => {
+    expect(getSetLoadKg({ weight: 50, unit: 'kg' }, ctx)).toBeCloseTo(50);
+    expect(getSetLoadKg({ isBodyweight: true }, ctx)).toBeCloseTo(80);
+    expect(getSetLoadKg({ weight: 20, unit: 'kg', isBodyweight: true }, ctx)).toBeCloseTo(100);
+  });
+
+  it('deriveRestMs computes rests between sets', () => {
+    const sets = [
+      { performedAt: '2024-01-01T10:00:00Z' },
+      { performedAt: '2024-01-01T10:01:30Z' },
+      { performedAt: '2024-01-01T10:03:00Z' },
+    ];
+    expect(deriveRestMs(sets)).toEqual([90000, 90000]);
+  });
+
+  it('calculators return totals and series', () => {
+    const day = '2024-01-01';
+    const ctxByDay = {
+      [day]: {
+        sets: [{ weight: 20, reps: 5 }],
+        activeMinutes: 10,
+        restMs: [60000],
+        workMsTotal: 30000,
+      },
+    };
+    const density = calcDensityKgPerMin(ctxByDay, { includeBodyweight: false, bodyweightKg: 80 });
+    expect(density.totals.density_kg_min).toBeGreaterThan(0);
+    const avgRest = calcAvgRestMs(ctxByDay);
+    expect(avgRest.totals.avg_rest_ms).toBe(60000);
+    const eff = calcSetEfficiencyPct(ctxByDay);
+    expect(eff.totals.set_efficiency_pct).toBeGreaterThan(0);
+  });
+});

--- a/src/services/metrics-v2/__tests__/engine.integration.test.ts
+++ b/src/services/metrics-v2/__tests__/engine.integration.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { calcDensityKgPerMin } from '../engine/calculators';
+import { toVolumeSeries } from '../engine/seriesAdapter';
+
+describe('engine integration', () => {
+  it('computes density for bodyweight sets when included', () => {
+    const day = '2024-02-01';
+    const sets = [{ isBodyweight: true, reps: 10, performedAt: `${day}T10:00:00Z` }];
+    const ctxByDay = { [day]: { sets, activeMinutes: 10 } } as any;
+    const off = calcDensityKgPerMin(ctxByDay, { includeBodyweight: false, bodyweightKg: 80 });
+    expect(off.totals.density_kg_min).toBe(0);
+    const on = calcDensityKgPerMin(ctxByDay, { includeBodyweight: true, bodyweightKg: 80 });
+    expect(on.totals.density_kg_min).toBeGreaterThan(0);
+  });
+
+  it('returns series points when sets produce volume', () => {
+    const sets = [{ isBodyweight: true, reps: 10, performedAt: '2024-02-01T10:00:00Z' }];
+    const series = toVolumeSeries(sets, { includeBodyweight: true, bodyweightKg: 80 });
+    expect(series.length).toBeGreaterThan(0);
+  });
+});

--- a/src/services/metrics-v2/engine/calculators.ts
+++ b/src/services/metrics-v2/engine/calculators.ts
@@ -1,0 +1,136 @@
+// Metrics v2 engine calculators and helpers
+import { TimeSeriesPoint } from '../dto';
+
+// Simple unit converter
+function convertToKg(weight?: number, unit: string = 'kg'): number {
+  if (!weight || isNaN(weight)) return 0;
+  return unit === 'lb' ? weight * 0.453592 : weight;
+}
+
+// Load factor lookup for bodyweight movements
+function loadFactor(_exerciseId?: string): number {
+  // Placeholder - would normally look up per exercise
+  return 1;
+}
+
+export interface LoadCtx {
+  includeBodyweight: boolean;
+  bodyweightKg: number;
+}
+
+export interface SetLike {
+  weight?: number | null;
+  unit?: string;
+  reps?: number | null;
+  isBodyweight?: boolean;
+  exerciseId?: string;
+  performedAt?: string; // ISO timestamp
+  workMs?: number;
+}
+
+export function getSetLoadKg(set: SetLike, ctx: LoadCtx): number {
+  const base = convertToKg(set.weight ?? undefined, set.unit) || 0;
+  const bw = ctx.includeBodyweight && set.isBodyweight
+    ? ctx.bodyweightKg * loadFactor(set.exerciseId)
+    : 0;
+  return base + bw;
+}
+
+export function getSetVolumeKg(set: SetLike, ctx: LoadCtx): number {
+  const loadKg = getSetLoadKg(set, ctx);
+  return loadKg * (set.reps ?? 0);
+}
+
+export function deriveRestMs(setsInWorkout: SetLike[]): number[] {
+  const rests: number[] = [];
+  const ordered = [...setsInWorkout].sort((a, b) => {
+    const ta = new Date(a.performedAt ?? 0).getTime();
+    const tb = new Date(b.performedAt ?? 0).getTime();
+    return ta - tb;
+  });
+  for (let i = 0; i < ordered.length - 1; i++) {
+    const cur = new Date(ordered[i].performedAt ?? 0).getTime();
+    const next = new Date(ordered[i + 1].performedAt ?? 0).getTime();
+    const diff = next - cur;
+    if (!isNaN(diff) && diff >= 0) rests.push(diff);
+  }
+  return rests;
+}
+
+export interface DayContext {
+  sets: SetLike[];
+  activeMinutes: number; // minutes of work (duration - rest)
+  restMs?: number[]; // optional precomputed rest durations
+  workMsTotal?: number; // optional precomputed work time
+}
+
+export interface CalcResult {
+  totals: Record<string, number>;
+  series: Record<string, TimeSeriesPoint[]>;
+}
+
+export function calcDensityKgPerMin(
+  ctxByDay: Record<string, DayContext>,
+  loadCtx: LoadCtx
+): CalcResult {
+  const series: TimeSeriesPoint[] = [];
+  let totalVolume = 0;
+  let totalActive = 0;
+  for (const day of Object.keys(ctxByDay).sort()) {
+    const ctx = ctxByDay[day];
+    const vol = ctx.sets.reduce((s, set) => s + getSetVolumeKg(set, loadCtx), 0);
+    const density = vol / Math.max(1, ctx.activeMinutes);
+    series.push({ date: day, value: +density.toFixed(2) });
+    totalVolume += vol;
+    totalActive += ctx.activeMinutes;
+  }
+  const totalDensity = totalVolume / Math.max(1, totalActive);
+  return {
+    totals: { density_kg_min: +totalDensity.toFixed(2) },
+    series: { density_kg_min: series },
+  };
+}
+
+export function calcAvgRestMs(
+  ctxByDay: Record<string, DayContext>
+): CalcResult {
+  const series: TimeSeriesPoint[] = [];
+  let sum = 0;
+  let count = 0;
+  for (const day of Object.keys(ctxByDay).sort()) {
+    const ctx = ctxByDay[day];
+    const rests = ctx.restMs ?? deriveRestMs(ctx.sets);
+    const avg = rests.length ? rests.reduce((a, b) => a + b, 0) / rests.length : 0;
+    series.push({ date: day, value: Math.floor(avg) });
+    sum += avg * rests.length;
+    count += rests.length;
+  }
+  const total = count ? Math.floor(sum / count) : 0;
+  return {
+    totals: { avg_rest_ms: total },
+    series: { avg_rest_ms: series },
+  };
+}
+
+export function calcSetEfficiencyPct(
+  ctxByDay: Record<string, DayContext>
+): CalcResult {
+  const series: TimeSeriesPoint[] = [];
+  let totalWork = 0;
+  let totalRest = 0;
+  for (const day of Object.keys(ctxByDay).sort()) {
+    const ctx = ctxByDay[day];
+    const rests = ctx.restMs ?? deriveRestMs(ctx.sets);
+    const restTotal = rests.reduce((a, b) => a + b, 0);
+    const workMs = ctx.workMsTotal ?? ctx.sets.reduce((s, set) => s + (set.workMs ?? (set.reps ?? 0) * 1000), 0);
+    const pct = workMs + restTotal > 0 ? (100 * workMs) / (workMs + restTotal) : 0;
+    series.push({ date: day, value: +pct.toFixed(2) });
+    totalWork += workMs;
+    totalRest += restTotal;
+  }
+  const totalPct = totalWork + totalRest > 0 ? (100 * totalWork) / (totalWork + totalRest) : 0;
+  return {
+    totals: { set_efficiency_pct: +totalPct.toFixed(2) },
+    series: { set_efficiency_pct: series },
+  };
+}

--- a/src/services/metrics-v2/engine/seriesAdapter.ts
+++ b/src/services/metrics-v2/engine/seriesAdapter.ts
@@ -1,0 +1,40 @@
+import { getSetLoadKg } from './calculators';
+import type { SetLike, LoadCtx } from './calculators';
+import { TimeSeriesPoint } from '../dto';
+
+export interface SeriesAdapterOpts extends LoadCtx {
+  start?: Date;
+  end?: Date;
+  includeBodyweightLoads?: boolean; // alias
+}
+
+export function toVolumeSeries(
+  sets: SetLike[],
+  opts: SeriesAdapterOpts
+): TimeSeriesPoint[] {
+  const includeBodyweight = opts.includeBodyweightLoads ?? opts.includeBodyweight;
+  const ctx: LoadCtx = { includeBodyweight, bodyweightKg: opts.bodyweightKg };
+  let withLoad = 0;
+  let bwDerived = 0;
+  const map = new Map<string, number>();
+
+  for (const s of sets) {
+    const load = getSetLoadKg(s, ctx);
+    if (load > 0) {
+      withLoad++;
+      if (includeBodyweight && s.isBodyweight) bwDerived++;
+      const vol = load * (s.reps ?? 0);
+      const date = (s.performedAt ?? '').split('T')[0];
+      if (date) map.set(date, (map.get(date) || 0) + vol);
+    }
+  }
+  const series = Array.from(map.entries())
+    .map(([date, value]) => ({ date, value }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+
+  console.debug(
+    `[v2][audit] inputSets:${sets.length} inRange:${sets.length} withLoad>0:${withLoad} bwDerived:${bwDerived} points:${series.length}`
+  );
+
+  return series;
+}

--- a/src/services/metrics-v2/registry.ts
+++ b/src/services/metrics-v2/registry.ts
@@ -1,0 +1,35 @@
+import { calcDensityKgPerMin, calcAvgRestMs, calcSetEfficiencyPct } from './engine/calculators';
+
+export interface MetricDef {
+  id: string;
+  units: string;
+  category: string;
+  aggregation: string;
+  calculator: any;
+}
+
+export const METRIC_DEFS: MetricDef[] = [
+  {
+    id: 'density_kg_min',
+    units: 'kg/min',
+    category: 'efficiency',
+    aggregation: 'timeseries/day',
+    calculator: calcDensityKgPerMin,
+  },
+  {
+    id: 'avg_rest_ms',
+    units: 'ms',
+    category: 'rest',
+    aggregation: 'timeseries/day',
+    calculator: calcAvgRestMs,
+  },
+  {
+    id: 'set_efficiency_pct',
+    units: '%',
+    category: 'efficiency',
+    aggregation: 'timeseries/day',
+    calculator: calcSetEfficiencyPct,
+  },
+];
+
+export const DEFS_VERSION = 2;


### PR DESCRIPTION
## Summary
- register density, average rest, and set efficiency in metrics v2 registry
- implement bodyweight-aware calculators and series adapter
- wire hook and analytics page to v2 totals & series
- add tests for calculator utilities and analytics UI

## Testing
- `npx vitest run src/services/metrics-v2/__tests__/engine.calculators.test.ts src/services/metrics-v2/__tests__/engine.integration.test.ts`
- `npm test` *(fails: chart container zero size; analytics route missing QueryClient provider)*

------
https://chatgpt.com/codex/tasks/task_e_68b315aec25c8326a08ea262217a8774