### PR TITLE
chore: add CI test scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "build:dev": "vite build --mode development",
     "lint": "npm run check:db-types && eslint .",
     "preview": "vite preview",
-    "test": "vitest run",
+    "test": "vitest",
+    "test:unit": "vitest run",
+    "test:ci": "vitest run --reporter=dot",
     "check:db-types": "npx supabase gen types typescript --project-id oglcdlzomfuoyeqeobal > /tmp/supabase-types.ts && diff -q /tmp/supabase-types.ts src/integrations/supabase/types.ts && rm /tmp/supabase-types.ts"
   },
   "dependencies": {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['tests/setup.ts'],
     globals: true,
-    include: ['src/**/*.{test,spec}.{ts,tsx,js}', 'supabase/tests/**/*.test.js', 'supabase/tests/**/*.spec.js', 'src/**/__tests__/*.{ts,tsx,js}'],
+    include: ['src/**/*.{test,spec}.{ts,tsx,js}', 'tests/**/*.{test,spec}.{ts,tsx,js}', 'supabase/tests/**/*.test.js', 'supabase/tests/**/*.spec.js', 'src/**/__tests__/*.{ts,tsx,js}'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- add `test`, `test:unit`, and `test:ci` scripts to package.json
- include top-level `tests/` directory in vitest config
- remove leftover Supabase mock test file

## Testing
- `npm run test:ci` *(fails: Unable to find an element with the text: 30s)*

------
https://chatgpt.com/codex/tasks/task_e_68b33a25660083268d62edd37104158f