### PR TITLE
feat: expand chart adapter with rest and efficiency metrics

### DIFF
--- a/src/services/metrics-v2/__tests__/ChartAdapter.test.ts
+++ b/src/services/metrics-v2/__tests__/ChartAdapter.test.ts
@@ -14,4 +14,14 @@ describe('chartAdapter', () => {
       { date: '2024-05-01', value: 5 },
     ]);
   });
+
+  it('maps rest and efficiency metrics with Warsaw date conversion', () => {
+    const out = toChartSeries(v2Payload);
+    expect(out.series.avg_rest_sec).toEqual([
+      { date: '2024-05-02', value: 90 },
+    ]);
+    expect(out.series.set_efficiency_kg_per_min).toEqual([
+      { date: '2024-05-01', value: 1.5 },
+    ]);
+  });
 });

--- a/src/services/metrics-v2/__tests__/metrics-v2.fixture.ts
+++ b/src/services/metrics-v2/__tests__/metrics-v2.fixture.ts
@@ -10,6 +10,12 @@ export const v2Payload = {
     densityKgPerMin: [
       { timestamp: '2024-05-01T06:00:00Z', value: 5 },
     ],
+    avgRestSec: [
+      { ts: '2024-05-01T23:00:00Z', value: 90 },
+    ],
+    setEfficiencyKgPerMin: [
+      { ts: '2024-05-01T21:00:00Z', value: 1.5 },
+    ],
   },
 };
 
@@ -25,6 +31,18 @@ export const expectedChartSeries = {
     density_kg_per_min: [
       { date: '2024-05-01', value: 5 },
     ],
+    avg_rest_sec: [
+      { date: '2024-05-02', value: 90 },
+    ],
+    set_efficiency_kg_per_min: [
+      { date: '2024-05-01', value: 1.5 },
+    ],
   },
-  availableMeasures: ['tonnage_kg', 'duration_min', 'density_kg_per_min'],
+  availableMeasures: [
+    'tonnage_kg',
+    'duration_min',
+    'density_kg_per_min',
+    'avg_rest_sec',
+    'set_efficiency_kg_per_min',
+  ],
 };


### PR DESCRIPTION
## Summary
- handle avgRestSec and setEfficiencyKgPerMin in chart adapter with Warsaw date conversion
- log rest and efficiency presence for debugging
- test adapter mapping for new metrics

## Testing
- `npm run typecheck` *(fails: Missing script "typecheck")*
- `npm run lint` *(failed: npx supabase gen types ... hangs)*
- `npm run test:ci` *(fails: TimePeriodAveragesCalculator.test.ts > calculates this month averages correctly; engine.calculators.test.ts > handles Warsaw day bucketing)*

------
https://chatgpt.com/codex/tasks/task_e_68b38fcd5b108326ba7500be6c8516b2