### PR TITLE
Add rest efficiency audit log and coverage calculation

### DIFF
--- a/docs/rest-efficiency-log.md
+++ b/docs/rest-efficiency-log.md
@@ -1,0 +1,21 @@
+# Rest Efficiency Logging
+
+This document describes the diagnostic logs emitted by the metrics v2 service for monitoring rest-related data quality.
+
+## `[v2.audit.rest_eff]`
+One-time audit log that checks whether derived rest efficiency metrics are present.
+
+Fields:
+- `hasKpi` – `true` when set efficiency KPI totals are available.
+- `hasSeries` – `true` when set efficiency time series exists.
+- `restCoveragePct` – percentage of potential rest intervals that include explicit rest values (0–100).
+
+## `[v2.build.rest_eff]`
+Summary log emitted after metrics are built.
+
+Fields:
+- `restCoveragePct` – percent of rest intervals with data (0–100).
+- `avgRestSec` – average rest duration in seconds (0–600).
+- `setEfficiencyKgPerMin` – set efficiency metric (0–10).
+
+Use these logs to monitor rest data coverage and the availability of efficiency metrics.

--- a/src/services/metrics-v2/__tests__/computePctOfSetsWithNonNullRest.test.ts
+++ b/src/services/metrics-v2/__tests__/computePctOfSetsWithNonNullRest.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { computePctOfSetsWithNonNullRest } from '../service'
+
+describe('computePctOfSetsWithNonNullRest', () => {
+  it('calculates rest coverage across workouts', () => {
+    const sets = [
+      { workoutId: 'w1', restTimeSec: null },
+      { workoutId: 'w1', restTimeSec: 30 },
+      { workoutId: 'w1', restTimeSec: null },
+      { workoutId: 'w2', restTimeSec: null },
+      { workoutId: 'w2', restTimeSec: 45 },
+    ] as any
+    const pct = computePctOfSetsWithNonNullRest(sets)
+    expect(pct).toBeCloseTo(66.67, 2)
+  })
+
+  it('returns 0 when no rest data', () => {
+    const sets = [
+      { workoutId: 'w1', restTimeSec: null },
+      { workoutId: 'w1', restTimeSec: null },
+    ] as any
+    const pct = computePctOfSetsWithNonNullRest(sets)
+    expect(pct).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary
- compute percentage of sets with explicit rest tracking
- log rest efficiency KPI/series presence and coverage
- document rest efficiency log fields for monitoring

## Testing
- `npm run typecheck` *(fails: Missing script "typecheck")*
- `npm run lint` *(fails: Supabase CLI step hangs; ran `npx eslint .` – 962 problems)*
- `npm run test:ci` *(partial run, interrupted)*
- `npx vitest run src/services/metrics-v2/__tests__/computePctOfSetsWithNonNullRest.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b4294c4eac83268c9d8bbba6c5c967