### PR TITLE
Surface density metric and format units

### DIFF
--- a/src/pages/analytics/AnalyticsPage.tsx
+++ b/src/pages/analytics/AnalyticsPage.tsx
@@ -174,6 +174,19 @@ export const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ data }) => {
     return ids.filter(id => availableMeasures.includes(id));
   }, [availableMeasures, derivedEnabled, baseIds]);
 
+  const formatValue = React.useCallback(
+    (n: number) => {
+      if (currentMeasure === DENSITY_ID || currentMeasure === EFF_ID) {
+        return fmtKgPerMin(n);
+      }
+      if (currentMeasure === AVG_REST_ID) {
+        return fmtSeconds(n);
+      }
+      return n.toString();
+    },
+    [currentMeasure]
+  );
+
   const baseTotals = React.useMemo(
     () => {
       if (v2Enabled && v2Data) {
@@ -401,12 +414,13 @@ export const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ data }) => {
                   fontSize={12}
                   tick={{ fill: 'hsl(var(--muted-foreground))' }}
                 />
-                <YAxis 
+                <YAxis
                   stroke="hsl(var(--muted-foreground))"
                   fontSize={12}
                   tick={{ fill: 'hsl(var(--muted-foreground))' }}
+                  tickFormatter={formatValue}
                 />
-                <Tooltip 
+                <Tooltip
                   contentStyle={{
                     backgroundColor: 'hsl(var(--card))',
                     border: '1px solid hsl(var(--border))',
@@ -414,6 +428,7 @@ export const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ data }) => {
                     color: 'hsl(var(--foreground))',
                     fontSize: '14px'
                   }}
+                  formatter={(value: number) => formatValue(value)}
                 />
                 <Line 
                   type="monotone" 

--- a/src/pages/analytics/__tests__/AnalyticsPage.chart.test.tsx
+++ b/src/pages/analytics/__tests__/AnalyticsPage.chart.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { AnalyticsPage } from '../AnalyticsPage';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { renderWithProviders } from '../../../../tests/utils/renderWithProviders';
+import { fireEvent, within } from '@testing-library/react';
 
 vi.mock('recharts', async () => await import('../../../../tests/mocks/recharts'));
 
@@ -37,5 +38,26 @@ describe('AnalyticsPage chart', () => {
     );
     expect(getByTestId('chart')).toBeDefined();
     expect(queryByTestId('measure-note')).toBeNull();
+  });
+
+  it('formats density axis and tooltip with kg/min', () => {
+    const data = {
+      series: {
+        density_kg_per_min: [{ date: '2024-01-01', value: 5 }],
+      },
+      metricKeys: ['density_kg_per_min'],
+    };
+    const { getByTestId } = renderWithProviders(
+      <TooltipProvider>
+        <AnalyticsPage data={data} />
+      </TooltipProvider>
+    );
+    const chart = getByTestId('chart');
+    const before = within(chart).getAllByText(/kg\/min/).length;
+    expect(before).toBeGreaterThan(0);
+    const dot = chart.querySelector('.recharts-line-dot');
+    if (dot) fireEvent.mouseOver(dot);
+    const after = within(chart).getAllByText(/kg\/min/).length;
+    expect(after).toBeGreaterThan(before);
   });
 });

--- a/src/services/metrics-v2/__tests__/ChartAdapter.test.ts
+++ b/src/services/metrics-v2/__tests__/ChartAdapter.test.ts
@@ -15,6 +15,14 @@ describe('chartAdapter', () => {
     ]);
   });
 
+  it('maps legacy density key to density_kg_per_min', () => {
+    const payload = { series: { density: [{ timestamp: '2024-05-01T06:00:00Z', value: 7 }] } };
+    const out = toChartSeries(payload);
+    expect(out.series.density_kg_per_min).toEqual([
+      { date: '2024-05-01', value: 7 },
+    ]);
+  });
+
   it('maps rest and efficiency metrics with Warsaw date conversion', () => {
     const out = toChartSeries(v2Payload);
     expect(out.series.avg_rest_sec).toEqual([

--- a/src/services/metrics-v2/chartAdapter.ts
+++ b/src/services/metrics-v2/chartAdapter.ts
@@ -11,6 +11,7 @@ const CANONICAL_KEYS = new Set([
 ]);
 const KEY_MAP: Record<string, string> = {
   densityKgPerMin: 'density_kg_per_min',
+  density: 'density_kg_per_min',
   avgRestSec: 'avg_rest_sec',
   setEfficiencyKgPerMin: 'set_efficiency_kg_per_min',
 };


### PR DESCRIPTION
## Summary
- Map legacy `density` key to `density_kg_per_min` in metrics adapter
- Format density chart with `kg/min` units on axis and tooltip
- Test coverage for adapter mapping and density formatting

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run test:ci` *(fails: RangeError: Invalid count value: Infinity)*
- `npx vitest run` *(fails: multiple failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b42f10b1b883268ae9b6ccd696dc0d