### PR TITLE
Surface density metric and format units

### DIFF
--- a/docs/analytics-metric-ids.md
+++ b/docs/analytics-metric-ids.md
@@ -3,7 +3,7 @@
 Metrics v2 exposes canonical identifiers for analytics.
 
 - `tonnage_kg` – total load in kilograms
-- `density_kg_min` – tonnage per minute
+- `density_kg_per_min` – tonnage per minute
 - `avg_rest_sec` – average rest time per set (seconds)
 - `set_efficiency_kg_per_min` – set efficiency in kilograms per minute
 

--- a/src/pages/analytics/AnalyticsPage.tsx
+++ b/src/pages/analytics/AnalyticsPage.tsx
@@ -174,6 +174,19 @@ export const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ data }) => {
     return ids.filter(id => availableMeasures.includes(id));
   }, [availableMeasures, derivedEnabled, baseIds]);
 
+  const formatValue = React.useCallback(
+    (n: number) => {
+      if (currentMeasure === DENSITY_ID || currentMeasure === EFF_ID) {
+        return fmtKgPerMin(n);
+      }
+      if (currentMeasure === AVG_REST_ID) {
+        return fmtSeconds(n);
+      }
+      return n.toString();
+    },
+    [currentMeasure]
+  );
+
   const baseTotals = React.useMemo(
     () => {
       if (v2Enabled && v2Data) {
@@ -401,12 +414,13 @@ export const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ data }) => {
                   fontSize={12}
                   tick={{ fill: 'hsl(var(--muted-foreground))' }}
                 />
-                <YAxis 
+                <YAxis
                   stroke="hsl(var(--muted-foreground))"
                   fontSize={12}
                   tick={{ fill: 'hsl(var(--muted-foreground))' }}
+                  tickFormatter={formatValue}
                 />
-                <Tooltip 
+                <Tooltip
                   contentStyle={{
                     backgroundColor: 'hsl(var(--card))',
                     border: '1px solid hsl(var(--border))',
@@ -414,6 +428,7 @@ export const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ data }) => {
                     color: 'hsl(var(--foreground))',
                     fontSize: '14px'
                   }}
+                  formatter={(value: number) => formatValue(value)}
                 />
                 <Line 
                   type="monotone" 

--- a/src/pages/analytics/__tests__/AnalyticsPage.chart.test.tsx
+++ b/src/pages/analytics/__tests__/AnalyticsPage.chart.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { AnalyticsPage } from '../AnalyticsPage';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { renderWithProviders } from '../../../../tests/utils/renderWithProviders';
+import { fireEvent, within } from '@testing-library/react';
 
 vi.mock('recharts', async () => await import('../../../../tests/mocks/recharts'));
 
@@ -37,5 +38,26 @@ describe('AnalyticsPage chart', () => {
     );
     expect(getByTestId('chart')).toBeDefined();
     expect(queryByTestId('measure-note')).toBeNull();
+  });
+
+  it('formats density axis and tooltip with kg/min', () => {
+    const data = {
+      series: {
+        density_kg_per_min: [{ date: '2024-01-01', value: 5 }],
+      },
+      metricKeys: ['density_kg_per_min'],
+    };
+    const { getByTestId } = renderWithProviders(
+      <TooltipProvider>
+        <AnalyticsPage data={data} />
+      </TooltipProvider>
+    );
+    const chart = getByTestId('chart');
+    const before = within(chart).getAllByText(/kg\/min/).length;
+    expect(before).toBeGreaterThan(0);
+    const dot = chart.querySelector('.recharts-line-dot');
+    if (dot) fireEvent.mouseOver(dot);
+    const after = within(chart).getAllByText(/kg\/min/).length;
+    expect(after).toBeGreaterThan(before);
   });
 });

--- a/src/services/metrics-v2/__tests__/ChartAdapter.test.ts
+++ b/src/services/metrics-v2/__tests__/ChartAdapter.test.ts
@@ -15,6 +15,14 @@ describe('chartAdapter', () => {
     ]);
   });
 
+  it('maps legacy density key to density_kg_per_min', () => {
+    const payload = { series: { density: [{ timestamp: '2024-05-01T06:00:00Z', value: 7 }] } };
+    const out = toChartSeries(payload);
+    expect(out.series.density_kg_per_min).toEqual([
+      { date: '2024-05-01', value: 7 },
+    ]);
+  });
+
   it('maps rest and efficiency metrics with Warsaw date conversion', () => {
     const out = toChartSeries(v2Payload);
     expect(out.series.avg_rest_sec).toEqual([

--- a/src/services/metrics-v2/__tests__/__snapshots__/ServiceOutput.test.ts.snap
+++ b/src/services/metrics-v2/__tests__/__snapshots__/ServiceOutput.test.ts.snap
@@ -15,7 +15,7 @@ exports[`ServiceOutput shape (v2) > returns a versioned, canonical structure 1`]
   "series": {
     "avgRestSec": [],
     "cvr": [],
-    "density_kg_min": [],
+    "density_kg_per_min": [],
     "duration_min": [],
     "reps_total": [],
     "setEfficiencyKgPerMin": [],

--- a/src/services/metrics-v2/__tests__/engine.calculators.test.ts
+++ b/src/services/metrics-v2/__tests__/engine.calculators.test.ts
@@ -38,7 +38,7 @@ describe('engine calculators', () => {
       },
     };
     const density = calcDensityKgPerMin(ctxByDay, { includeBodyweight: false, bodyweightKg: 80 });
-    expect(density.totals.density_kg_min).toBeGreaterThan(0);
+    expect(density.totals.density_kg_per_min).toBeGreaterThan(0);
     const avgRest = calcAvgRestSec(ctxByDay);
     expect(avgRest.totals.avgRestSec).toBe(60);
     const eff = calcSetEfficiencyKgPerMin(ctxByDay, { includeBodyweight: false, bodyweightKg: 0 });

--- a/src/services/metrics-v2/__tests__/engine.integration.test.ts
+++ b/src/services/metrics-v2/__tests__/engine.integration.test.ts
@@ -8,9 +8,9 @@ describe('engine integration', () => {
     const sets = [{ isBodyweight: true, reps: 10, performedAt: `${day}T10:00:00Z` }];
     const ctxByDay = { [day]: { sets, activeMinutes: 10 } } as any;
     const off = calcDensityKgPerMin(ctxByDay, { includeBodyweight: false, bodyweightKg: 80 });
-    expect(off.totals.density_kg_min).toBe(0);
+    expect(off.totals.density_kg_per_min).toBe(0);
     const on = calcDensityKgPerMin(ctxByDay, { includeBodyweight: true, bodyweightKg: 80 });
-    expect(on.totals.density_kg_min).toBeGreaterThan(0);
+    expect(on.totals.density_kg_per_min).toBeGreaterThan(0);
   });
 
   it('returns series points when sets produce volume', () => {

--- a/src/services/metrics-v2/chartAdapter.ts
+++ b/src/services/metrics-v2/chartAdapter.ts
@@ -11,6 +11,8 @@ const CANONICAL_KEYS = new Set([
 ]);
 const KEY_MAP: Record<string, string> = {
   densityKgPerMin: 'density_kg_per_min',
+  density: 'density_kg_per_min',
+  density_kg_min: 'density_kg_per_min',
   avgRestSec: 'avg_rest_sec',
   setEfficiencyKgPerMin: 'set_efficiency_kg_per_min',
 };

--- a/src/services/metrics-v2/dto.ts
+++ b/src/services/metrics-v2/dto.ts
@@ -31,7 +31,7 @@ export type Totals = {
   reps_total: number;
   workouts: number;
   duration_min: number;
-  density_kg_min?: number;
+  density_kg_per_min?: number;
   avgRestSec?: number;
   setEfficiencyKgPerMin?: number;
 };

--- a/src/services/metrics-v2/engine/calculators.ts
+++ b/src/services/metrics-v2/engine/calculators.ts
@@ -104,8 +104,8 @@ export function calcDensityKgPerMin(
   }
   const totalDensity = totalActive > 0 ? totalVolume / totalActive : 0;
   return {
-    totals: { density_kg_min: +totalDensity.toFixed(2) },
-    series: { density_kg_min: series },
+    totals: { density_kg_per_min: +totalDensity.toFixed(2) },
+    series: { density_kg_per_min: series },
   };
 }
 

--- a/src/services/metrics-v2/index.ts
+++ b/src/services/metrics-v2/index.ts
@@ -139,7 +139,7 @@ export async function getMetricsV2(
     tonnage_kg: mapSeries(w => w.totalVolumeKg),
     sets_count: mapSeries(w => w.totalSets),
     reps_total: mapSeries(w => w.totalReps),
-    density_kg_min: densityRes.series.density_kg_min,
+    density_kg_per_min: densityRes.series.density_kg_per_min,
     cvr: [],
     workouts: mapSeries(() => 1),
     duration_min: mapSeries(w => w.durationMin),

--- a/src/services/metrics-v2/registry.ts
+++ b/src/services/metrics-v2/registry.ts
@@ -14,7 +14,7 @@ export interface MetricDef {
 
 export const METRIC_DEFS: MetricDef[] = [
   {
-    id: 'density_kg_min',
+    id: 'density_kg_per_min',
     units: 'kg/min',
     category: 'efficiency',
     aggregation: 'timeseries/day',


### PR DESCRIPTION
## Summary
- Map legacy `density`/`density_kg_min` keys to canonical `density_kg_per_min`
- Rename metrics engine to emit `density_kg_per_min` and update registry, DTO, and service
- Test coverage and docs updated for new density metric ID

## Testing
- `npx tsc --noEmit`
- `npx eslint .` *(fails: 474 errors, 488 warnings)*
- `npm run test:ci` *(fails: RangeError: Invalid count value: Infinity)*

------
https://chatgpt.com/codex/tasks/task_e_68b42f10b1b883268ae9b6ccd696dc0d