### PR TITLE
feat: expose density metric

### DIFF
--- a/docs/analytics-metric-ids.md
+++ b/docs/analytics-metric-ids.md
@@ -3,7 +3,7 @@
 Metrics v2 exposes canonical identifiers for analytics.
 
 - `tonnage_kg` – total load in kilograms
-- `density_kg_min` – tonnage per minute
+- `density_kg_per_min` – tonnage per minute
 - `avg_rest_sec` – average rest time per set (seconds)
 - `set_efficiency_kg_per_min` – set efficiency in kilograms per minute
 

--- a/src/services/metrics-v2/__tests__/ChartAdapter.test.ts
+++ b/src/services/metrics-v2/__tests__/ChartAdapter.test.ts
@@ -23,6 +23,14 @@ describe('chartAdapter', () => {
     ]);
   });
 
+  it('maps legacy density_kg_min to density_kg_per_min', () => {
+    const payload = { series: { density_kg_min: [{ timestamp: '2024-05-01T06:00:00Z', value: 9 }] } };
+    const out = toChartSeries(payload);
+    expect(out.series.density_kg_per_min).toEqual([
+      { date: '2024-05-01', value: 9 },
+    ]);
+  });
+
   it('maps rest and efficiency metrics with Warsaw date conversion', () => {
     const out = toChartSeries(v2Payload);
     expect(out.series.avg_rest_sec).toEqual([

--- a/src/services/metrics-v2/__tests__/__snapshots__/ServiceOutput.test.ts.snap
+++ b/src/services/metrics-v2/__tests__/__snapshots__/ServiceOutput.test.ts.snap
@@ -15,7 +15,7 @@ exports[`ServiceOutput shape (v2) > returns a versioned, canonical structure 1`]
   "series": {
     "avgRestSec": [],
     "cvr": [],
-    "density_kg_min": [],
+    "density_kg_per_min": [],
     "duration_min": [],
     "reps_total": [],
     "setEfficiencyKgPerMin": [],

--- a/src/services/metrics-v2/__tests__/engine.calculators.test.ts
+++ b/src/services/metrics-v2/__tests__/engine.calculators.test.ts
@@ -38,7 +38,7 @@ describe('engine calculators', () => {
       },
     };
     const density = calcDensityKgPerMin(ctxByDay, { includeBodyweight: false, bodyweightKg: 80 });
-    expect(density.totals.density_kg_min).toBeGreaterThan(0);
+    expect(density.totals.density_kg_per_min).toBeGreaterThan(0);
     const avgRest = calcAvgRestSec(ctxByDay);
     expect(avgRest.totals.avgRestSec).toBe(60);
     const eff = calcSetEfficiencyKgPerMin(ctxByDay, { includeBodyweight: false, bodyweightKg: 0 });

--- a/src/services/metrics-v2/__tests__/engine.integration.test.ts
+++ b/src/services/metrics-v2/__tests__/engine.integration.test.ts
@@ -8,9 +8,9 @@ describe('engine integration', () => {
     const sets = [{ isBodyweight: true, reps: 10, performedAt: `${day}T10:00:00Z` }];
     const ctxByDay = { [day]: { sets, activeMinutes: 10 } } as any;
     const off = calcDensityKgPerMin(ctxByDay, { includeBodyweight: false, bodyweightKg: 80 });
-    expect(off.totals.density_kg_min).toBe(0);
+    expect(off.totals.density_kg_per_min).toBe(0);
     const on = calcDensityKgPerMin(ctxByDay, { includeBodyweight: true, bodyweightKg: 80 });
-    expect(on.totals.density_kg_min).toBeGreaterThan(0);
+    expect(on.totals.density_kg_per_min).toBeGreaterThan(0);
   });
 
   it('returns series points when sets produce volume', () => {

--- a/src/services/metrics-v2/chartAdapter.ts
+++ b/src/services/metrics-v2/chartAdapter.ts
@@ -12,6 +12,7 @@ const CANONICAL_KEYS = new Set([
 const KEY_MAP: Record<string, string> = {
   densityKgPerMin: 'density_kg_per_min',
   density: 'density_kg_per_min',
+  density_kg_min: 'density_kg_per_min',
   avgRestSec: 'avg_rest_sec',
   setEfficiencyKgPerMin: 'set_efficiency_kg_per_min',
 };

--- a/src/services/metrics-v2/dto.ts
+++ b/src/services/metrics-v2/dto.ts
@@ -31,7 +31,7 @@ export type Totals = {
   reps_total: number;
   workouts: number;
   duration_min: number;
-  density_kg_min?: number;
+  density_kg_per_min?: number;
   avgRestSec?: number;
   setEfficiencyKgPerMin?: number;
 };

--- a/src/services/metrics-v2/engine/calculators.ts
+++ b/src/services/metrics-v2/engine/calculators.ts
@@ -104,8 +104,8 @@ export function calcDensityKgPerMin(
   }
   const totalDensity = totalActive > 0 ? totalVolume / totalActive : 0;
   return {
-    totals: { density_kg_min: +totalDensity.toFixed(2) },
-    series: { density_kg_min: series },
+    totals: { density_kg_per_min: +totalDensity.toFixed(2) },
+    series: { density_kg_per_min: series },
   };
 }
 

--- a/src/services/metrics-v2/index.ts
+++ b/src/services/metrics-v2/index.ts
@@ -139,7 +139,7 @@ export async function getMetricsV2(
     tonnage_kg: mapSeries(w => w.totalVolumeKg),
     sets_count: mapSeries(w => w.totalSets),
     reps_total: mapSeries(w => w.totalReps),
-    density_kg_min: densityRes.series.density_kg_min,
+    density_kg_per_min: densityRes.series.density_kg_per_min,
     cvr: [],
     workouts: mapSeries(() => 1),
     duration_min: mapSeries(w => w.durationMin),

--- a/src/services/metrics-v2/registry.ts
+++ b/src/services/metrics-v2/registry.ts
@@ -14,7 +14,7 @@ export interface MetricDef {
 
 export const METRIC_DEFS: MetricDef[] = [
   {
-    id: 'density_kg_min',
+    id: 'density_kg_per_min',
     units: 'kg/min',
     category: 'efficiency',
     aggregation: 'timeseries/day',


### PR DESCRIPTION
## Summary
- expose density_kg_per_min from engine and registry
- map legacy density keys and include in chart adapter output
- document density metric

## Testing
- `npm run typecheck` *(fails: Missing script)*
- `npm run lint`
- `npm run test:ci` *(fails: timePeriodAveragesCalculator.test.ts: expected 3 to be 2)*

------
https://chatgpt.com/codex/tasks/task_e_68b435462ff88326b0dbf71918bd5b28