### PR TITLE
chore: add typecheck script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "npm run check:db-types && eslint .",
+    "typecheck": "tsc --noEmit",
     "preview": "vite preview",
     "test": "vitest",
     "test:unit": "vitest run",


### PR DESCRIPTION
## Summary
- add `typecheck` npm script to run `tsc --noEmit`

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: node-domexception 1.0.0 deprecation warning, command terminated)*
- `npm run test:ci` *(fails: RangeError Invalid count value: Infinity)*

------
https://chatgpt.com/codex/tasks/task_e_68b4773eb7988326b16941cc6fc7b42d