### PR TITLE
feat: add rest and efficiency analytics

### DIFF
--- a/src/pages/analytics/AnalyticsPage.tsx
+++ b/src/pages/analytics/AnalyticsPage.tsx
@@ -169,7 +169,7 @@ export const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ data }) => {
   // Use currentMeasure after it's properly initialized
   const series = React.useMemo(() => {
     const raw = seriesData[currentMeasure] ?? [];
-    return raw.map(p => ({ date: p.date, value: (p as any).value ?? null }));
+    return raw.map(p => ({ date: p.date, value: p?.value ?? null }));
   }, [seriesData, currentMeasure]);
   const unavailable = series.length === 0;
   const dropdownOptions = React.useMemo(() => {

--- a/src/pages/analytics/__tests__/AnalyticsPage.chart.test.tsx
+++ b/src/pages/analytics/__tests__/AnalyticsPage.chart.test.tsx
@@ -60,4 +60,25 @@ describe('AnalyticsPage chart', () => {
     const after = within(chart).getAllByText(/kg\/min/).length;
     expect(after).toBeGreaterThan(before);
   });
+
+  it('renders gap when series contains null', () => {
+    const data = {
+      series: {
+        tonnage_kg: [
+          { date: '2024-01-01', value: 5 },
+          { date: '2024-01-02', value: null },
+          { date: '2024-01-03', value: 7 },
+        ],
+      },
+      metricKeys: ['tonnage_kg'],
+    };
+    const { getByTestId } = renderWithProviders(
+      <TooltipProvider>
+        <AnalyticsPage data={data} />
+      </TooltipProvider>
+    );
+    const path = getByTestId('chart').querySelector('.recharts-line-curve');
+    const d = path?.getAttribute('d') || '';
+    expect(d.split('M').length).toBeGreaterThan(2);
+  });
 });

--- a/src/pages/analytics/__tests__/MetricSelector.test.tsx
+++ b/src/pages/analytics/__tests__/MetricSelector.test.tsx
@@ -54,6 +54,28 @@ describe('metric selector and KPI gating', () => {
     expect(screen.getByTestId('kpi-density')).toBeInTheDocument();
   });
 
+  it('hides rest and efficiency when flag off', () => {
+    (FEATURE_FLAGS as any).ANALYTICS_DERIVED_KPIS_ENABLED = false;
+    const client = new QueryClient();
+    const series = {
+      [TONNAGE_ID]: [{ date: '2024-01-01', value: 1 }],
+      [AVG_REST_ID]: [{ date: '2024-01-01', value: 30 }],
+      [EFF_ID]: [{ date: '2024-01-01', value: 1 }],
+    } as Record<string, TimeSeriesPoint[]>;
+    const totals = { ...baseTotals, [AVG_REST_ID]: 30, [EFF_ID]: 1 };
+    render(
+      <QueryClientProvider client={client}>
+        <TooltipProvider>
+          <AnalyticsPage data={{ perWorkout: [], series, totals }} />
+        </TooltipProvider>
+      </QueryClientProvider>
+    );
+    const trigger = screen.getByTestId('metric-select');
+    fireEvent.click(trigger);
+    expect(screen.queryByText('Avg Rest (sec)')).toBeNull();
+    expect(screen.queryByText('Set Efficiency (kg/min)')).toBeNull();
+  });
+
   it('shows rest and efficiency options when data available', () => {
     (FEATURE_FLAGS as any).ANALYTICS_DERIVED_KPIS_ENABLED = true;
     const client = new QueryClient();

--- a/src/pages/analytics/measureOptions.ts
+++ b/src/pages/analytics/measureOptions.ts
@@ -1,4 +1,12 @@
-import { TONNAGE_ID, SETS_ID, REPS_ID, DURATION_ID, DENSITY_ID } from './metricIds';
+import {
+  TONNAGE_ID,
+  SETS_ID,
+  REPS_ID,
+  DURATION_ID,
+  DENSITY_ID,
+  AVG_REST_ID,
+  EFF_ID,
+} from './metricIds';
 
 export const BASE_MEASURES = [
   { id: TONNAGE_ID, label: 'Tonnage (kg)' },
@@ -9,6 +17,8 @@ export const BASE_MEASURES = [
 
 export const DERIVED_MEASURES = [
   { id: DENSITY_ID, label: 'Density (kg/min)' },
+  { id: AVG_REST_ID, label: 'Avg Rest (sec)' },
+  { id: EFF_ID, label: 'Set Efficiency (kg/min)' },
 ];
 
 export const MEASURES = [...BASE_MEASURES, ...DERIVED_MEASURES];


### PR DESCRIPTION
## Summary
- add Avg Rest and Set Efficiency to derived measure options
- map metric series without `any` and keep chart gaps
- gate new metrics and dropdown options behind flag

## Testing
- `npm run typecheck`
- `npx eslint .` *(fails: Unexpected any errors in unrelated files)*
- `npm run test:ci` *(fails: RangeError: Invalid count value)*

------
https://chatgpt.com/codex/tasks/task_e_68b486738d5c8326832e475dde1ff566