### PR TITLE
refactor: add robust analytics formatters

### DIFF
--- a/src/pages/analytics/AnalyticsPage.tsx
+++ b/src/pages/analytics/AnalyticsPage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { PerWorkoutMetrics } from '@/services/metrics-v2/dto';
 import type { TimeSeriesPoint } from '@/services/metrics-v2/types';
-import { formatKgPerMin, fmtSeconds } from './formatters';
+import { formatKgPerMin, formatSeconds } from './formatters';
 import { setFlagOverride, useFeatureFlags } from '@/constants/featureFlags';
 import {
   TONNAGE_ID,
@@ -184,7 +184,7 @@ export const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ data }) => {
         return formatKgPerMin(n);
       }
       if (currentMeasure === AVG_REST_ID) {
-        return fmtSeconds(n);
+        return formatSeconds(n);
       }
       return n.toString();
     },
@@ -362,7 +362,7 @@ export const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ data }) => {
           </div>
           <div data-testid="kpi-rest" className="bg-gradient-to-br from-accent/10 to-accent/5 backdrop-blur-sm p-4 rounded-lg border border-accent/20 hover:border-accent/40 transition-all group">
             <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-1">Avg Rest (sec)</div>
-            <div className="text-2xl font-bold text-foreground group-hover:text-accent-foreground transition-colors">{fmtSeconds(kpiTotals.avgRestSec)}</div>
+            <div className="text-2xl font-bold text-foreground group-hover:text-accent-foreground transition-colors">{formatSeconds(kpiTotals.avgRestSec)}</div>
           </div>
           <div data-testid="kpi-efficiency" className="bg-gradient-to-br from-primary/10 to-primary/5 backdrop-blur-sm p-4 rounded-lg border border-primary/20 hover:border-primary/40 transition-all group">
             <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-1">Set Efficiency (kg/min)</div>

--- a/src/pages/analytics/__tests__/formatters.test.ts
+++ b/src/pages/analytics/__tests__/formatters.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { toFinite, formatSeconds, formatKgPerMin } from '../formatters';
+
+describe('analytics formatters', () => {
+  it('toFinite returns 0 for non-finite values', () => {
+    expect(toFinite(5)).toBe(5);
+    expect(toFinite(null)).toBe(0);
+    expect(toFinite(undefined)).toBe(0);
+    expect(toFinite(NaN)).toBe(0);
+    expect(toFinite(Infinity)).toBe(0);
+  });
+
+  it('formatSeconds formats seconds with units', () => {
+    expect(formatSeconds(125)).toBe('2m 5s');
+    expect(formatSeconds(null)).toBe('0m 0s');
+  });
+
+  it('formatKgPerMin formats numbers with units', () => {
+    expect(formatKgPerMin(12.345)).toBe('12.35 kg/min');
+    expect(formatKgPerMin(undefined)).toBe('0 kg/min');
+  });
+});

--- a/src/pages/analytics/formatters.ts
+++ b/src/pages/analytics/formatters.ts
@@ -1,20 +1,18 @@
 // Formatting helpers for analytics metrics
 
-export const toFinite = (n: number) => (Number.isFinite(n) ? n : 0);
+export const toFinite = (n: number | null | undefined): number =>
+  typeof n === 'number' && Number.isFinite(n) ? n : 0;
 
 const numberFmt = new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 });
 const formatNumber = (n: number) => numberFmt.format(n);
 
-export const formatKgPerMin = (v: number) => `${formatNumber(toFinite(v))} kg/min`;
+export const formatKgPerMin = (v: number | null | undefined): string =>
+  `${formatNumber(toFinite(v))} kg/min`;
 
-export function fmtSeconds(n: number): string {
-  const v = Number.isFinite(n) ? Math.max(0, n) : 0;
-  const minutes = Math.floor(v / 60);
-  const seconds = Math.round(v % 60);
+export const formatSeconds = (v: number | null | undefined): string => {
+  const total = Math.max(0, toFinite(v));
+  const minutes = Math.floor(total / 60);
+  const seconds = Math.round(total % 60);
   return `${minutes}m ${seconds}s`;
-}
+};
 
-export function fmtRatio(n: number | null): string {
-  if (n === null || !Number.isFinite(n)) return 'N/A';
-  return `${n.toFixed(2)}×`;
-}


### PR DESCRIPTION
## Summary
- handle null and undefined in analytics format helpers
- provide seconds and kg/min formatting utilities
- cover formatters with unit tests

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run test:ci` *(fails: RangeError: Invalid count value: Infinity)*

------
https://chatgpt.com/codex/tasks/task_e_68b48ae16bac8326afd5c32ee9c02c6f