### PR TITLE
feat(metrics): include timing metadata for sets

### DIFF
--- a/src/services/metrics-v2/__tests__/engine.calculators.test.ts
+++ b/src/services/metrics-v2/__tests__/engine.calculators.test.ts
@@ -7,6 +7,7 @@ import {
   calcSetEfficiencyKgPerMin,
   restCoveragePct,
 } from '../engine/calculators';
+import { deriveRestMs as deriveRestMsFixed } from '../engine/restCalculatorsFixed';
 import { buildDayContexts } from '../engine/dayContextBuilder';
 
 const ctx = { includeBodyweight: true, bodyweightKg: 80 };
@@ -25,6 +26,36 @@ describe('engine calculators', () => {
       { performedAt: '2024-01-01T10:03:00Z' },
     ];
     expect(deriveRestMs(sets)).toEqual([90000, 90000]);
+  });
+
+  it('deriveRestMsFixed uses start and completion times when available', () => {
+    const sets = [
+      {
+        workoutId: 'w1',
+        exerciseName: 'bench',
+        startedAt: '2024-01-01T10:00:00Z',
+        completedAt: '2024-01-01T10:00:30Z',
+        reps: 5,
+        weightKg: 50,
+      },
+      {
+        workoutId: 'w1',
+        exerciseName: 'bench',
+        startedAt: '2024-01-01T10:02:00Z',
+        completedAt: '2024-01-01T10:02:30Z',
+        reps: 5,
+        weightKg: 50,
+      },
+    ];
+    expect(deriveRestMsFixed(sets)).toEqual([90000]);
+  });
+
+  it('deriveRestMsFixed returns empty array with missing timing', () => {
+    const sets = [
+      { workoutId: 'w1', exerciseName: 'bench', reps: 5, weightKg: 50 },
+      { workoutId: 'w1', exerciseName: 'bench', reps: 5, weightKg: 50 },
+    ];
+    expect(deriveRestMsFixed(sets as any)).toEqual([]);
   });
 
   it('calculators return totals and series', () => {

--- a/src/services/metrics-v2/repository/supabase.ts
+++ b/src/services/metrics-v2/repository/supabase.ts
@@ -89,7 +89,7 @@ export class SupabaseMetricsRepository implements MetricsRepository {
       // Primary RLS-safe join query
       let { data: sets, error } = await this.client
         .from('exercise_sets')
-        .select('id, workout_id, exercise_id, exercise_name, weight, reps, completed, failure_point, form_quality, rest_time, workout_sessions!inner(id,user_id)')
+        .select('id, workout_id, exercise_id, exercise_name, weight, reps, completed, failure_point, form_quality, rest_time, started_at, completed_at, timing_quality, workout_sessions!inner(id,user_id)')
         .in('workout_id', ownedIds)
         .eq('workout_sessions.user_id', userId)
         .or('completed.is.null,completed.eq.true')
@@ -99,7 +99,7 @@ export class SupabaseMetricsRepository implements MetricsRepository {
         // Fallback: non-join query (still constrained to ownedIds)
         const alt = await this.client
           .from('exercise_sets')
-          .select('id, workout_id, exercise_id, exercise_name, weight, reps, completed, failure_point, form_quality, rest_time')
+          .select('id, workout_id, exercise_id, exercise_name, weight, reps, completed, failure_point, form_quality, rest_time, started_at, completed_at, timing_quality')
           .in('workout_id', ownedIds)
         if (alt.error || !alt.data) {
           console.error('[MetricsV2] Fallback sets query also failed:', alt.error)
@@ -123,6 +123,9 @@ export class SupabaseMetricsRepository implements MetricsRepository {
         failurePoint: s.failure_point ?? null,
         formScore: s.form_quality ?? null,
         restTimeSec: s.rest_time ?? null,
+        startedAt: s.started_at ?? undefined,
+        completedAt: s.completed_at ?? undefined,
+        timingQuality: s.timing_quality ?? undefined,
       }))
     } catch (error) {
       console.error('[MetricsV2] Error in getSets:', error)

--- a/src/services/metrics-v2/types.ts
+++ b/src/services/metrics-v2/types.ts
@@ -24,6 +24,9 @@ export interface SetRaw {
   failurePoint?: 'none'|'technical'|'muscular' | null;
   formScore?: number | null;
   restTimeSec?: number;
+  startedAt?: string;
+  completedAt?: string;
+  timingQuality?: 'actual' | 'estimated' | 'missing';
 }
 
 export interface MetricsRepository {


### PR DESCRIPTION
## Summary
- expose `started_at`, `completed_at`, and `timing_quality` when retrieving sets from Supabase
- extend `SetRaw` and metrics assembly to forward set timing fields
- test rest calculator handling of explicit and missing timing data

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: requires Supabase CLI auth, eslint reports existing `any` usage)*
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68b4bf44c0948326a56a9592cff9fe78