### PR TITLE
feat(metrics): add sets and reps key mapping

### DIFF
--- a/src/services/metrics-v2/__tests__/ChartAdapter.test.ts
+++ b/src/services/metrics-v2/__tests__/ChartAdapter.test.ts
@@ -104,7 +104,7 @@ describe('chartAdapter', () => {
     ]);
     expect(out.series.setEfficiencyKgPerMin).toBe(out.series.set_efficiency_kg_per_min);
     const values = out.series.set_efficiency_kg_per_min.map(p => p.value);
-    expect(values.some(v => Number.isNaN(v as any) || v === Infinity || v === -Infinity)).toBe(false);
+    expect(values.some(v => Number.isNaN(v as number) || v === Infinity || v === -Infinity)).toBe(false);
   });
 
   it('skips rest and efficiency when includeDerived is false', () => {
@@ -120,5 +120,19 @@ describe('chartAdapter', () => {
     expect(out.series).not.toHaveProperty('set_efficiency_kg_per_min');
     expect(out.availableMeasures).not.toContain('avg_rest_sec');
     expect(out.availableMeasures).not.toContain('set_efficiency_kg_per_min');
+  });
+
+  it('maps sets_count and reps_total to canonical keys', () => {
+    const payload = {
+      series: {
+        sets_count: [{ timestamp: '2024-05-01T06:00:00Z', value: 3 }],
+        reps_total: [{ timestamp: '2024-05-01T06:00:00Z', value: 30 }],
+      },
+    };
+    const out = toChartSeries(payload);
+    expect(out.series.sets).toEqual([{ date: '2024-05-01', value: 3 }]);
+    expect(out.series.reps).toEqual([{ date: '2024-05-01', value: 30 }]);
+    expect(out.availableMeasures).toContain('sets');
+    expect(out.availableMeasures).toContain('reps');
   });
 });

--- a/src/services/metrics-v2/chartAdapter.ts
+++ b/src/services/metrics-v2/chartAdapter.ts
@@ -17,6 +17,12 @@ const KEY_MAP: Record<string, string> = {
   density_kg_min: 'density_kg_per_min',
   avgRestSec: 'avg_rest_sec',
   setEfficiencyKgPerMin: 'set_efficiency_kg_per_min',
+  set_count: 'sets',
+  sets_count: 'sets',
+  total_sets: 'sets',
+  rep_count: 'reps',
+  reps_total: 'reps',
+  total_reps: 'reps',
 };
 
 // Mirror camelCase/snake_case keys so consumers can access either form


### PR DESCRIPTION
## Summary
- translate set and rep count aliases to canonical `sets`/`reps` in chart adapter
- cover mapping for new canonical keys in chart adapter tests

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: process hangs when fetching supabase types)*
- `npx eslint src/services/metrics-v2/chartAdapter.ts src/services/metrics-v2/__tests__/ChartAdapter.test.ts`
- `npm run test:ci` *(fails: SupabaseMetricsRepository methods missing `.limit`/`.or` during tests)*
- `npx vitest run src/services/metrics-v2/__tests__/ChartAdapter.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b57c1de39c83269501be13f0789343