### PR TITLE
test: add sets and reps metrics to chart adapter

### DIFF
--- a/src/services/metrics-v2/__tests__/ChartAdapter.test.ts
+++ b/src/services/metrics-v2/__tests__/ChartAdapter.test.ts
@@ -122,16 +122,10 @@ describe('chartAdapter', () => {
     expect(out.availableMeasures).not.toContain('set_efficiency_kg_per_min');
   });
 
-  it('maps sets_count and reps_total to canonical keys', () => {
-    const payload = {
-      series: {
-        sets_count: [{ timestamp: '2024-05-01T06:00:00Z', value: 3 }],
-        reps_total: [{ timestamp: '2024-05-01T06:00:00Z', value: 30 }],
-      },
-    };
-    const out = toChartSeries(payload);
-    expect(out.series.sets).toEqual([{ date: '2024-05-01', value: 3 }]);
-    expect(out.series.reps).toEqual([{ date: '2024-05-01', value: 30 }]);
+  it('includes sets and reps series and measures', () => {
+    const out = toChartSeries(v2Payload);
+    expect(out.series.sets).toEqual(expectedChartSeries.series.sets);
+    expect(out.series.reps).toEqual(expectedChartSeries.series.reps);
     expect(out.availableMeasures).toContain('sets');
     expect(out.availableMeasures).toContain('reps');
   });

--- a/src/services/metrics-v2/__tests__/metrics-v2.fixture.ts
+++ b/src/services/metrics-v2/__tests__/metrics-v2.fixture.ts
@@ -16,6 +16,14 @@ export const v2Payload = {
     setEfficiencyKgPerMin: [
       { ts: '2024-05-01T21:00:00Z', value: 1.5 },
     ],
+    sets_count: [
+      { timestamp: '2024-05-01T06:00:00Z', value: 3 },
+      { timestamp: '2024-05-02T06:00:00Z', value: 4 },
+    ],
+    reps_total: [
+      { timestamp: '2024-05-01T06:00:00Z', value: 30 },
+      { timestamp: '2024-05-02T06:00:00Z', value: 40 },
+    ],
   },
 };
 
@@ -27,6 +35,14 @@ const durationSeries = [{ date: '2024-05-01', value: 60 }];
 const densitySeries = [{ date: '2024-05-01', value: 5 }];
 const restSeries = [{ date: '2024-05-02', value: 90 }];
 const efficiencySeries = [{ date: '2024-05-01', value: 1.5 }];
+const setsSeries = [
+  { date: '2024-05-01', value: 3 },
+  { date: '2024-05-02', value: 4 },
+];
+const repsSeries = [
+  { date: '2024-05-01', value: 30 },
+  { date: '2024-05-02', value: 40 },
+];
 
 export const expectedChartSeries = {
   series: {
@@ -40,6 +56,8 @@ export const expectedChartSeries = {
     avgRestSec: restSeries,
     set_efficiency_kg_per_min: efficiencySeries,
     setEfficiencyKgPerMin: efficiencySeries,
+    sets: setsSeries,
+    reps: repsSeries,
   },
   availableMeasures: [
     'tonnage_kg',
@@ -47,5 +65,7 @@ export const expectedChartSeries = {
     'density_kg_per_min',
     'avg_rest_sec',
     'set_efficiency_kg_per_min',
+    'sets',
+    'reps',
   ],
 };


### PR DESCRIPTION
## Summary
- extend metrics-v2 fixture with sets_count and reps_total sample data
- verify chart adapter exposes `sets` and `reps` series and measures

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: process did not terminate)*
- `npm run test:ci` *(fails: RangeError: Invalid count value: Infinity)*

------
https://chatgpt.com/codex/tasks/task_e_68b57ee2b1ec832680e473ddca0d35e0