### PR TITLE
feat: add rest timing fields to exercise sets

### DIFF
--- a/src/types/exercise.ts
+++ b/src/types/exercise.ts
@@ -4,6 +4,10 @@ export interface ExerciseSet {
   reps: number;
   duration?: number;
   restTime?: number; // Properly defined restTime property
+  // Optional rest timing fields for enhanced tracking
+  restStartedAt?: number;
+  restMs?: number;
+  restFrozen?: boolean;
   completed: boolean;
   isEditing?: boolean;
   set_number: number;

--- a/src/types/workout-enhanced.ts
+++ b/src/types/workout-enhanced.ts
@@ -11,6 +11,10 @@ export interface ExerciseSet {
   weight: number;
   reps: number;
   restTime: number;
+  // Optional rest timing fields for enhanced tracking
+  restStartedAt?: number;
+  restMs?: number;
+  restFrozen?: boolean;
   completed: boolean;
   isEditing: boolean;
   isWarmup?: boolean;

--- a/tests/exercise-set-rest-fields.test.ts
+++ b/tests/exercise-set-rest-fields.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'vitest';
+import type { ExerciseSet as WorkoutExerciseSet } from '@/types/workout-enhanced';
+import type { ExerciseSet as ExerciseExerciseSet } from '@/types/exercise';
+
+describe('ExerciseSet rest fields', () => {
+  test('workout-enhanced ExerciseSet accepts rest fields', () => {
+    const set: WorkoutExerciseSet = {
+      weight: 100,
+      reps: 5,
+      restTime: 60,
+      completed: false,
+      isEditing: false,
+      restStartedAt: 0,
+      restMs: 30000,
+      restFrozen: true,
+    };
+    expect(set.restMs).toBe(30000);
+    expect(set.restFrozen).toBe(true);
+  });
+
+  test('exercise.ts ExerciseSet accepts rest fields', () => {
+    const set: ExerciseExerciseSet = {
+      id: 's1',
+      weight: 100,
+      reps: 5,
+      completed: false,
+      set_number: 1,
+      exercise_name: 'Bench Press',
+      workout_id: 'w1',
+      restStartedAt: 0,
+      restMs: 30000,
+      restFrozen: false,
+    };
+    expect(set.restFrozen).toBe(false);
+    expect(set.restStartedAt).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- extend ExerciseSet types with optional rest timing metadata
- cover new fields with a minimal type-level test

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: Access token not provided)*
- `npm run test:ci` *(fails: RangeError: Invalid count value: Infinity)*
- `npm run test:unit` *(fails: AnalyticsPage chart shows derived options when flag enabled; SupabaseMetricsRepository tests)*


------
https://chatgpt.com/codex/tasks/task_e_68b6eb7ef7bc8326860a5cc89400e0b7