### PR TITLE
feat: add REST_FREEZE_ON_START flag

### DIFF
--- a/src/constants/__tests__/featureFlags.test.ts
+++ b/src/constants/__tests__/featureFlags.test.ts
@@ -7,6 +7,7 @@ beforeEach(() => {
   localStorage.clear();
   delete process.env.VITE_KPI_ANALYTICS_ENABLED;
   delete process.env.VITE_ANALYTICS_DERIVED_KPIS_ENABLED;
+  delete process.env.VITE_REST_FREEZE_ON_START;
 });
 
 afterAll(async () => {
@@ -21,6 +22,7 @@ describe('featureFlags precedence', () => {
     expect(FEATURE_FLAGS.KPI_ANALYTICS_ENABLED).toBe(true);
     expect(FEATURE_FLAGS.ANALYTICS_DERIVED_KPIS_ENABLED).toBe(false);
     expect(FEATURE_FLAGS.SETUP_CHOOSE_EXERCISES_ENABLED).toBe(true);
+    expect(FEATURE_FLAGS.REST_FREEZE_ON_START).toBe(false);
   });
 
   it.skip('env overrides defaults', async () => {

--- a/src/constants/featureFlags.ts
+++ b/src/constants/featureFlags.ts
@@ -6,6 +6,7 @@ export type FeatureFlags = {
   ANALYTICS_V2_ENABLED: boolean;
   SETUP_CHOOSE_EXERCISES_ENABLED: boolean;
   SET_COMPLETE_NOTIFICATIONS_ENABLED: boolean;
+  REST_FREEZE_ON_START: boolean;
 };
 
 const DEFAULTS: FeatureFlags = {
@@ -14,6 +15,7 @@ const DEFAULTS: FeatureFlags = {
   ANALYTICS_V2_ENABLED: false,
   SETUP_CHOOSE_EXERCISES_ENABLED: true,
   SET_COMPLETE_NOTIFICATIONS_ENABLED: false,
+  REST_FREEZE_ON_START: false,
 };
 
 const overrides: Partial<FeatureFlags> = {};
@@ -47,6 +49,7 @@ export const FEATURE_FLAGS: FeatureFlags = {
   ANALYTICS_V2_ENABLED: resolveFlag('ANALYTICS_V2_ENABLED'),
   SETUP_CHOOSE_EXERCISES_ENABLED: resolveFlag('SETUP_CHOOSE_EXERCISES_ENABLED'),
   SET_COMPLETE_NOTIFICATIONS_ENABLED: resolveFlag('SET_COMPLETE_NOTIFICATIONS_ENABLED'),
+  REST_FREEZE_ON_START: resolveFlag('REST_FREEZE_ON_START'),
 };
 
 export function setFlagOverride(name: keyof FeatureFlags, value: boolean) {


### PR DESCRIPTION
## Summary
- add `REST_FREEZE_ON_START` to feature flag types and defaults
- resolve new flag in exported `FEATURE_FLAGS`
- extend feature flag tests for new default

## Testing
- `npm run typecheck`
- `SUPABASE_ACCESS_TOKEN=foo npm run lint` *(fails: Invalid access token format)*
- `CI=true npm run test:ci` *(fails: repository gracefulDegradation and AnalyticsPage chart tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ed14b314832686d345060e5ef6ae