### PR TITLE
feat: freeze rest on set start

### DIFF
--- a/src/store/workoutStore.rest.test.ts
+++ b/src/store/workoutStore.rest.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const storePath = './workoutStore';
+
+describe('startSet with REST_FREEZE_ON_START', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+  });
+
+  it('handleCompleteSet stores restStartedAt', async () => {
+    const { useWorkoutStore } = await import(storePath);
+    await useWorkoutStore.persist.rehydrate();
+    const { setFlagOverride } = await import('@/constants/featureFlags');
+    setFlagOverride('REST_FREEZE_ON_START', true);
+    const base = useWorkoutStore.getState();
+    useWorkoutStore.setState({
+      ...base,
+      exercises: {
+        test: [
+          { weight: 0, reps: 0, restTime: 60, completed: false, isEditing: false }
+        ]
+      }
+    });
+
+    useWorkoutStore.getState().handleCompleteSet('test', 0);
+    const state = useWorkoutStore.getState();
+    const set0 = (state.exercises['test'] as any)[0];
+    expect(typeof set0.restStartedAt).toBe('number');
+  });
+});


### PR DESCRIPTION
## Summary
- add startSet to freeze previous set rest and audit logging
- record rest start when a set completes
- delegate set start timing to new helper under feature flag

## Testing
- `npm run typecheck`
- `npm run lint` (fails: npx supabase requires interactive confirmation)
- `npm run test:ci` (fails: SupabaseMetricsRepository tests - this.client.from(...).select is not a function)
- `npx vitest run src/store/workoutStore.rest.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b6f434d5d08326a407e13963988f5e