### PR TITLE
Use v2 analytics KPIs for dashboard cards

### DIFF
--- a/src/pages/analytics/__tests__/AnalyticsPage.density.test.tsx
+++ b/src/pages/analytics/__tests__/AnalyticsPage.density.test.tsx
@@ -10,12 +10,23 @@ vi.mock('recharts', async () => await import('../../../../tests/mocks/recharts')
 vi.mock('@/constants/featureFlags', () => ({
   useFeatureFlags: () => ({
     KPI_ANALYTICS_ENABLED: true,
+    KPI_DIAGNOSTICS_ENABLED: false,
     ANALYTICS_DERIVED_KPIS_ENABLED: false,
     ANALYTICS_V2_ENABLED: false,
     SETUP_CHOOSE_EXERCISES_ENABLED: false,
     SET_COMPLETE_NOTIFICATIONS_ENABLED: false,
+    REST_FREEZE_ON_START: false,
   }),
   setFlagOverride: vi.fn(),
+  FEATURE_FLAGS: {
+    KPI_ANALYTICS_ENABLED: true,
+    KPI_DIAGNOSTICS_ENABLED: false,
+    ANALYTICS_DERIVED_KPIS_ENABLED: false,
+    ANALYTICS_V2_ENABLED: false,
+    SETUP_CHOOSE_EXERCISES_ENABLED: false,
+    SET_COMPLETE_NOTIFICATIONS_ENABLED: false,
+    REST_FREEZE_ON_START: false,
+  },
 }));
 
 describe('AnalyticsPage density selector', () => {


### PR DESCRIPTION
## Summary
- source KPI card metrics directly from metrics v2 analytics
- add optional diagnostics logging for KPI values
- update density test feature flag mocks

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run test:ci` *(fails: RangeError: Invalid count value: Infinity)*

------
https://chatgpt.com/codex/tasks/task_e_68b7463bf2388326a4cce46dbed16ad0