### PR TITLE
feat: add KPI selector helpers for analytics

### DIFF
--- a/src/pages/analytics/AnalyticsPage.tsx
+++ b/src/pages/analytics/AnalyticsPage.tsx
@@ -11,7 +11,8 @@ import {
   type MetricId,
 } from './metricIds';
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
-import useMetricsV2, { useMetricsV2Analytics, type MetricsV2Data } from '@/hooks/useMetricsV2';
+import useMetricsV2, { useMetricsV2Analytics } from '@/hooks/useMetricsV2';
+import { getSets, getReps, getDuration, getTonnage, getDensity } from './kpiSelectors';
 import { useAuth } from '@/context/AuthContext';
 import { DateRangePicker } from '@/components/ui/date-range-picker';
 import { Switch } from '@/components/ui/switch';
@@ -195,26 +196,28 @@ export const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ data }) => {
 
   const baseTotals = React.useMemo(
     () => ({
-      sets: v2.data?.kpis.sets ?? 0,
-      reps: v2.data?.kpis.reps ?? 0,
-      duration: v2.data?.kpis.durationMin ?? 0,
-      tonnage: v2.data?.kpis.tonnageKg ?? 0,
+      sets: getSets(v2.data, serviceData?.totals),
+      reps: getReps(v2.data, serviceData?.totals),
+      duration: getDuration(v2.data, serviceData?.totals),
+      tonnage: getTonnage(v2.data, serviceData?.totals),
     }),
-    [v2.data?.kpis]
+    [v2.data, serviceData?.totals]
   );
 
   const kpiTotals = React.useMemo(
     () => ({
-      density: v2.data?.kpis.densityKgPerMin ?? 0,
+      density: getDensity(v2.data, serviceData?.totals),
       avgRestSec:
         derivedEnabled && timingQuality === 'high'
-          ? v2.data?.kpis.avgRestSec ?? 0
+          ? v2.data?.kpis.avgRestSec ?? v2.data?.totals?.[AVG_REST_ID] ?? serviceData?.totals?.[AVG_REST_ID] ?? 0
           : 0,
       efficiencyKgPerMin: derivedEnabled
-        ? v2.data?.kpis.setEfficiencyKgPerMin ?? 0
+        ? v2.data?.kpis.setEfficiencyKgPerMin ??
+          v2.data?.totals?.[EFF_ID] ??
+          serviceData?.totals?.[EFF_ID] ?? 0
         : 0,
     }),
-    [v2.data?.kpis, derivedEnabled, timingQuality]
+    [v2.data, serviceData?.totals, derivedEnabled, timingQuality]
   );
 
   React.useEffect(() => {

--- a/src/pages/analytics/__tests__/kpiSelectors.test.ts
+++ b/src/pages/analytics/__tests__/kpiSelectors.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { getSets, getReps, getDuration, getTonnage, getDensity } from '../kpiSelectors';
+import { SETS_ID, REPS_ID, DURATION_ID, TONNAGE_ID, DENSITY_ID } from '../metricIds';
+import type { MetricsV2Data } from '@/hooks/useMetricsV2';
+
+describe('kpiSelectors', () => {
+  const legacy = {
+    [SETS_ID]: 1,
+    [REPS_ID]: 2,
+    [DURATION_ID]: 3,
+    [TONNAGE_ID]: 4,
+    [DENSITY_ID]: 5,
+  } as Record<string, number>;
+
+  it('prefers kpis over totals and legacy', () => {
+    const v2 = {
+      kpis: { sets: 10, reps: 20, durationMin: 30, tonnageKg: 40, densityKgPerMin: 50 },
+      totals: { [SETS_ID]: 100, [REPS_ID]: 200, [DURATION_ID]: 300, [TONNAGE_ID]: 400, [DENSITY_ID]: 500 },
+    } as unknown as MetricsV2Data & { totals: Record<string, number> };
+    expect(getSets(v2, legacy)).toBe(10);
+    expect(getReps(v2, legacy)).toBe(20);
+    expect(getDuration(v2, legacy)).toBe(30);
+    expect(getTonnage(v2, legacy)).toBe(40);
+    expect(getDensity(v2, legacy)).toBe(50);
+  });
+
+  it('falls back to totals then legacy', () => {
+    const v2 = {
+      totals: { [SETS_ID]: 100, [REPS_ID]: 200, [DURATION_ID]: 300, [TONNAGE_ID]: 400, [DENSITY_ID]: 500 },
+    } as unknown as MetricsV2Data & { totals: Record<string, number> };
+    expect(getSets(v2, legacy)).toBe(100);
+    expect(getReps(v2, legacy)).toBe(200);
+    expect(getDuration(v2, legacy)).toBe(300);
+    expect(getTonnage(v2, legacy)).toBe(400);
+    expect(getDensity(v2, legacy)).toBe(500);
+  });
+
+  it('uses legacy when v2 data missing', () => {
+    expect(getSets(undefined, legacy)).toBe(1);
+    expect(getReps(undefined, legacy)).toBe(2);
+    expect(getDuration(undefined, legacy)).toBe(3);
+    expect(getTonnage(undefined, legacy)).toBe(4);
+    expect(getDensity(undefined, legacy)).toBe(5);
+  });
+
+  it('returns 0 when everything missing', () => {
+    expect(getSets()).toBe(0);
+    expect(getReps()).toBe(0);
+    expect(getDuration()).toBe(0);
+    expect(getTonnage()).toBe(0);
+    expect(getDensity()).toBe(0);
+  });
+});

--- a/src/pages/analytics/kpiSelectors.ts
+++ b/src/pages/analytics/kpiSelectors.ts
@@ -1,0 +1,43 @@
+import type { MetricsV2Data } from '@/hooks/useMetricsV2';
+import {
+  SETS_ID,
+  REPS_ID,
+  DURATION_ID,
+  TONNAGE_ID,
+  DENSITY_ID,
+} from './metricIds';
+
+export function getSets(
+  v2?: MetricsV2Data & { totals?: Record<string, number> },
+  legacyTotals?: Record<string, number>
+): number {
+  return v2?.kpis?.sets ?? v2?.totals?.[SETS_ID] ?? legacyTotals?.[SETS_ID] ?? 0;
+}
+
+export function getReps(
+  v2?: MetricsV2Data & { totals?: Record<string, number> },
+  legacyTotals?: Record<string, number>
+): number {
+  return v2?.kpis?.reps ?? v2?.totals?.[REPS_ID] ?? legacyTotals?.[REPS_ID] ?? 0;
+}
+
+export function getDuration(
+  v2?: MetricsV2Data & { totals?: Record<string, number> },
+  legacyTotals?: Record<string, number>
+): number {
+  return v2?.kpis?.durationMin ?? v2?.totals?.[DURATION_ID] ?? legacyTotals?.[DURATION_ID] ?? 0;
+}
+
+export function getTonnage(
+  v2?: MetricsV2Data & { totals?: Record<string, number> },
+  legacyTotals?: Record<string, number>
+): number {
+  return v2?.kpis?.tonnageKg ?? v2?.totals?.[TONNAGE_ID] ?? legacyTotals?.[TONNAGE_ID] ?? 0;
+}
+
+export function getDensity(
+  v2?: MetricsV2Data & { totals?: Record<string, number> },
+  legacyTotals?: Record<string, number>
+): number {
+  return v2?.kpis?.densityKgPerMin ?? v2?.totals?.[DENSITY_ID] ?? legacyTotals?.[DENSITY_ID] ?? 0;
+}


### PR DESCRIPTION
## Summary
- add reusable KPI selectors with v2 and legacy fallbacks
- update AnalyticsPage to use selectors for totals
- cover selectors with unit tests

## Testing
- `npm run typecheck`
- `npm run lint`
- `COLUMNS=80 LINES=24 npm run test:ci` *(fails: RangeError: Invalid count value: Infinity)*

------
https://chatgpt.com/codex/tasks/task_e_68b750c8e91c8326a8cd6d1bc47b2fa0