### PR TITLE
test: cover rest freeze edge cases

### DIFF
--- a/src/__tests__/setRow.pointerStart.test.tsx
+++ b/src/__tests__/setRow.pointerStart.test.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { SetRow } from '@/components/SetRow';
+import { setFlagOverride } from '@/constants/featureFlags';
+
+vi.mock('lucide-react', () => ({
+  MinusCircle: () => null,
+  PlusCircle: () => null,
+  Save: () => null,
+  Trash2: () => null,
+  Edit: () => null,
+  Check: () => null,
+  Timer: () => null,
+}));
+
+vi.mock('@/context/WeightUnitContext', () => ({ useWeightUnit: () => ({ weightUnit: 'kg' }) }));
+vi.mock('@/hooks/use-mobile', () => ({ useIsMobile: () => false }));
+vi.mock('@/hooks/useExerciseWeight', () => ({
+  useExerciseWeight: () => ({
+    weight: 0,
+    isAutoWeight: false,
+    weightSource: 'manual',
+    updateWeight: () => {},
+    resetToAuto: () => {},
+  }),
+}));
+vi.mock('@/components/ui/input', () => ({ Input: (props: any) => <input {...props} /> }));
+vi.mock('@/components/ui/button', () => ({ Button: (props: any) => <button {...props} /> }));
+vi.mock('@/components/ui/tooltip', () => ({
+  TooltipProvider: ({ children }: any) => <div>{children}</div>,
+  Tooltip: ({ children }: any) => <div>{children}</div>,
+  TooltipTrigger: ({ children }: any) => <div>{children}</div>,
+  TooltipContent: ({ children }: any) => <div>{children}</div>,
+}));
+vi.mock('@/hooks/useRestTimeAnalytics', () => ({ useRestTimeAnalytics: () => ({ logRestTime: () => {} }) }));
+vi.mock('@/hooks/useGlobalRestTimers', () => ({
+  useGlobalRestTimers: () => ({
+    generateTimerId: () => 'id',
+    isTimerActive: () => false,
+    stopTimer: () => {},
+    getTimer: () => null,
+  }),
+}));
+vi.mock('@/components/CompactRestTimer', () => ({ CompactRestTimer: () => null }));
+vi.mock('@/utils/restDisplay', () => ({
+  getDisplayRestLabelByIndex: () => ({ type: 'duration', value: 60 }),
+  formatRestForDisplay: () => '',
+}));
+
+const startSet = vi.fn();
+vi.mock('@/store/workoutStore', () => ({
+  useWorkoutStore: () => ({ startSet, setSetStartTime: () => {}, setSetEndTime: () => {} }),
+}));
+
+describe('SetRow startSet dispatch', () => {
+  beforeEach(() => {
+    startSet.mockReset();
+    setFlagOverride('REST_FREEZE_ON_START', true);
+  });
+
+  function renderRow() {
+    return render(
+      <SetRow
+        setNumber={1}
+        weight={0}
+        reps={0}
+        completed={false}
+        isEditing={true}
+        exerciseName="Bench"
+        onComplete={() => {}}
+        onEdit={() => {}}
+        onSave={() => {}}
+        onRemove={() => {}}
+        onWeightChange={() => {}}
+        onRepsChange={() => {}}
+        onWeightIncrement={() => {}}
+        onRepsIncrement={() => {}}
+        weightUnit="kg"
+      />,
+    );
+  }
+
+  test('pointerDown then input focus triggers startSet only once', () => {
+    const { getByPlaceholderText, getAllByRole } = renderRow();
+    fireEvent.pointerDown(getAllByRole('button')[0]);
+    const input = getByPlaceholderText('Weight');
+    fireEvent.focus(input);
+    expect(startSet).toHaveBeenCalledTimes(1);
+  });
+});
+

--- a/tests/restFlow.store.test.ts
+++ b/tests/restFlow.store.test.ts
@@ -98,6 +98,26 @@ describe('REST_FREEZE_ON_START flag', () => {
     expect(set0.restFrozen).toBe(true);
   });
 
+  test('fallback freeze when completing set without startSet', () => {
+    setFlagOverride('REST_FREEZE_ON_START', true);
+    const store = useWorkoutStore.getState();
+    store.handleCompleteSet('Bench Press', 0);
+    vi.setSystemTime(30_000);
+    store.handleCompleteSet('Bench Press', 1);
+    const sets = (useWorkoutStore.getState().exercises['Bench Press'] as any).sets as any[];
+    expect(sets[0].restMs).toBe(30_000);
+    expect(sets[0].restFrozen).toBe(true);
+    expect(sets[1].restStartedAt).toBe(30_000);
+  });
+
+  test('setSetStartTime wrapper passes correct index', () => {
+    setFlagOverride('REST_FREEZE_ON_START', true);
+    const state = useWorkoutStore.getState();
+    const spy = vi.spyOn(state, 'startSet');
+    state.setSetStartTime('Bench Press', 2);
+    expect(spy).toHaveBeenCalledWith('Bench Press', 2);
+  });
+
   test('flag OFF preserves legacy behavior', () => {
     setFlagOverride('REST_FREEZE_ON_START', false);
     const store = useWorkoutStore.getState();


### PR DESCRIPTION
## Summary
- add restFlow store tests for fallback freezing and set index passthrough
- add SetRow UI test ensuring startSet dispatch only once per set

## Testing
- `npm run typecheck`
- `npm run lint`
- `npx vitest run --reporter=basic` *(fails: SupabaseMetricsRepository Graceful Degradation, AnalyticsPage chart)*

------
https://chatgpt.com/codex/tasks/task_e_68b88f75a5f883269b26181ebedca72c