### PR TITLE
feat(metrics): add density fallback computation

### DIFF
--- a/src/services/metrics-v2/__tests__/normalizeTotals.test.ts
+++ b/src/services/metrics-v2/__tests__/normalizeTotals.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest';
+import { normalizeTotals } from '../chartAdapter';
+
+describe('normalizeTotals density fallback', () => {
+  it('computes density when missing and logs under diagnostics flag', () => {
+    const spy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    const out = normalizeTotals({ tonnage_kg: 100, duration_min: 20 });
+    expect(out.density_kg_per_min).toBe(5);
+    expect(spy).toHaveBeenCalledWith('[adapter] density fallback applied:', {
+      tonnage_kg: 100,
+      duration_min: 20,
+      density: 5,
+    });
+    spy.mockRestore();
+  });
+
+  it('computes density when provided as 0', () => {
+    const spy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    const out = normalizeTotals({
+      tonnage_kg: 50,
+      duration_min: 10,
+      density_kg_per_min: 0,
+    });
+    expect(out.density_kg_per_min).toBe(5);
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});

--- a/src/services/metrics-v2/__tests__/repository/gracefulDegradation.test.ts
+++ b/src/services/metrics-v2/__tests__/repository/gracefulDegradation.test.ts
@@ -38,7 +38,7 @@ describe('SupabaseMetricsRepository Graceful Degradation', () => {
 
   it('probes timing columns availability correctly', async () => {
     // Test successful probe (timing columns exist)
-    mockClient.select.mockResolvedValueOnce({ error: null, data: [] });
+    mockClient.limit.mockResolvedValueOnce({ error: null, data: [] });
     
     const available = await (repository as any).probeTimingColumns();
     expect(available).toBe(true);
@@ -49,9 +49,9 @@ describe('SupabaseMetricsRepository Graceful Degradation', () => {
 
   it('handles missing timing columns gracefully', async () => {
     // Test probe failure (timing columns missing)
-    mockClient.select.mockResolvedValueOnce({ 
-      error: { message: 'column "timing_quality" does not exist', code: '42703' }, 
-      data: null 
+    mockClient.limit.mockResolvedValueOnce({
+      error: { message: 'column "timing_quality" does not exist', code: '42703' },
+      data: null
     });
     
     const available = await (repository as any).probeTimingColumns();
@@ -93,7 +93,7 @@ describe('SupabaseMetricsRepository Graceful Degradation', () => {
 
   it('returns consistent interface regardless of schema state', async () => {
     // Mock workouts ownership check
-    mockClient.eq.mockResolvedValue({ error: null, data: [{ id: 'w1' }] });
+    mockClient.eq.mockResolvedValueOnce({ error: null, data: [{ id: 'w1' }] });
     
     // Test with timing columns available
     (repository as any).timingColumnsAvailable = true;


### PR DESCRIPTION
## Summary
- compute density_kg_per_min from tonnage and duration when missing
- log density fallback when diagnostics enabled
- add coverage for density fallback and repair supabase test mocks

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68b8aa35d42c8326b3c8f94626c638f7