### PR TITLE
Handle missing KPI values in analytics

### DIFF
--- a/src/pages/analytics/AnalyticsPage.tsx
+++ b/src/pages/analytics/AnalyticsPage.tsx
@@ -316,7 +316,7 @@ export const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ data }) => {
             <div key={spec.key} data-testid={`kpi-${spec.key}`} className="bg-gradient-to-br from-card to-card/70 backdrop-blur-sm p-4 rounded-lg border border-border/30 hover:border-primary/30 transition-all group">
               <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-1">{spec.label}</div>
               <div className="text-2xl font-bold text-foreground group-hover:text-primary transition-colors">
-                {typeof value === 'number' ? spec.formatter(value) : '0'}
+                {spec.formatter(value)}
               </div>
             </div>
           );
@@ -331,15 +331,15 @@ export const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ data }) => {
             .map((spec) => {
               const value = kpiTotals.derivedTotals[spec.key as keyof typeof kpiTotals.derivedTotals];
               const isAvailable = typeof value === 'number';
-              
+
               return (
                 <div key={spec.key} data-testid={`kpi-${spec.key}`} className={`
-                  bg-gradient-to-br from-secondary/10 to-secondary/5 backdrop-blur-sm p-4 rounded-lg border border-secondary/20 
+                  bg-gradient-to-br from-secondary/10 to-secondary/5 backdrop-blur-sm p-4 rounded-lg border border-secondary/20
                   ${isAvailable ? 'hover:border-secondary/40 transition-all group' : 'opacity-70'}
                 `}>
                   <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-1">{spec.label}</div>
                   <div className="text-2xl font-bold text-foreground group-hover:text-secondary transition-colors">
-                    {isAvailable ? spec.formatter(value) : 'N/A'}
+                    {spec.formatter(value)}
                   </div>
                 </div>
               );

--- a/src/pages/analytics/__tests__/kpiSpecs.test.ts
+++ b/src/pages/analytics/__tests__/kpiSpecs.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { coreKpiSpecs } from '../kpiSpecs';
+
+describe('kpiSpecs formatters', () => {
+  it('returns N/A for undefined values', () => {
+    const intSpec = coreKpiSpecs.find(s => s.key === 'sets')!;
+    const fixed0Spec = coreKpiSpecs.find(s => s.key === 'duration_min')!;
+    const fixed2Spec = coreKpiSpecs.find(s => s.key === 'density_kg_per_min')!;
+
+    expect(intSpec.formatter(undefined)).toBe('N/A');
+    expect(fixed0Spec.formatter(undefined)).toBe('N/A');
+    expect(fixed2Spec.formatter(undefined)).toBe('N/A');
+  });
+
+  it('formats zero values with precision', () => {
+    const fixed0Spec = coreKpiSpecs.find(s => s.key === 'duration_min')!;
+    const fixed2Spec = coreKpiSpecs.find(s => s.key === 'density_kg_per_min')!;
+
+    expect(fixed0Spec.formatter(0)).toBe('0');
+    expect(fixed2Spec.formatter(0)).toBe('0.00');
+  });
+});

--- a/src/pages/analytics/kpiSpecs.ts
+++ b/src/pages/analytics/kpiSpecs.ts
@@ -2,16 +2,17 @@ export type KpiSpec = {
   key: string;
   label: string;
   section: 'core' | 'derived';
-  formatter: (n: number) => string;
+  formatter: (n?: number) => string;
   flag?: 'ANALYTICS_DERIVED_KPIS_ENABLED';
 };
 
-const formatInt = (n: number): string => {
+const formatInt = (n?: number): string => {
+  if (n === undefined) return 'N/A';
   return n >= 1000 ? `${Math.round(n / 1000)}k` : Math.round(n).toString();
 };
 
-const formatFixed0 = (n: number): string => n.toFixed(0);
-const formatFixed2 = (n: number): string => n.toFixed(2);
+const formatFixed0 = (n?: number): string => (n === undefined ? 'N/A' : n.toFixed(0));
+const formatFixed2 = (n?: number): string => (n === undefined ? 'N/A' : n.toFixed(2));
 
 export const coreKpiSpecs: KpiSpec[] = [
   {


### PR DESCRIPTION
## Summary
- allow KPI formatters to accept missing numbers and output 'N/A'
- use optional-aware formatters throughout Analytics page
- test KPI formatter behavior for undefined and zero values

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run test:ci` *(fails: RangeError: Invalid count value: Infinity)*
- `npx vitest run src/pages/analytics/__tests__/kpiSpecs.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b8b53574dc8326a6a0a28b220e9a33